### PR TITLE
Reduce amount of RPC requests

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -37,14 +37,15 @@ jobs:
           REACT_APP_HOME_NETWORK: xdai
           REACT_APP_HOME_RPC_URL: https://rpc.xdaichain.com/
           REACT_APP_ENABLE_REVERSED_BRIDGE: false
-          REACT_APP_DEBUG_LOGS: true
+          REACT_APP_DEBUG_LOGS: false
           REACT_APP_TITLE: OmniBridge - %c
           REACT_APP_DESCRIPTION: 'The OmniBridge multi-token extension for the Arbitrary Message Bridge between Ethereum and the xDai chain is the simplest way to transfer ANY ERC20/ERC677/ERC827 token to the xDai chain.'
           REACT_APP_GAS_PRICE_SUPPLIER_URL: https://gasprice.poa.network/
           REACT_APP_GAS_PRICE_SPEED_TYPE: fast
-          REACT_APP_GAS_PRICE_UPDATE_INTERVAL: 15000
+          REACT_APP_GAS_PRICE_UPDATE_INTERVAL: 60000
           REACT_APP_ETH_PRICE_API_URL: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=USD'
           REACT_APP_ETH_PRICE_UPDATE_INTERVAL: 15000
+          REACT_APP_GRAPH_HEALTH_UPDATE_INTERVAL: 60000
 
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master

--- a/packages/react-app/src/lib/providers.js
+++ b/packages/react-app/src/lib/providers.js
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import memoize from 'fast-memoize';
 import { getRPCUrl, isxDaiChain } from 'lib/helpers';
 
-const memoized = memoize(url => new ethers.providers.JsonRpcProvider(url));
+const memoized = memoize(url => new ethers.providers.StaticJsonRpcProvider(url));
 
 export const getEthersProvider = chainId => {
   const localRPCUrl = window.localStorage.getItem(


### PR DESCRIPTION
- `StaticJsonRpcProvider` allows to get rid of chainId requests
- Increasing `REACT_APP_GAS_PRICE_UPDATE_INTERVAL` allows to reduce number of requests to the gas price oracle as so requests is being made every ~5 blocks
- Introduction of `REACT_APP_GRAPH_HEALTH_UPDATE_INTERVAL` and setting it to 60 seconds allows to reduce amount of `blockNumber` requests.