### PR TITLE
chore: utilize useweb3context in places to avoid usecontext redundancy

### DIFF
--- a/packages/react-app/src/components/bridge/BridgeTokens.jsx
+++ b/packages/react-app/src/components/bridge/BridgeTokens.jsx
@@ -15,13 +15,13 @@ import {
 } from 'components/warnings/ReverseWarning';
 import { BridgeContext } from 'contexts/BridgeContext';
 import { useSettings } from 'contexts/SettingsContext';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { FOREIGN_CHAIN_ID } from 'lib/constants';
 import { getBridgeNetwork, getNetworkName } from 'lib/helpers';
 import React, { useContext } from 'react';
 
 export const BridgeTokens = () => {
-  const { providerChainId: chainId } = useContext(Web3Context);
+  const { providerChainId: chainId } = useWeb3Context();
   const { fromToken, toToken, txHash, loading } = useContext(BridgeContext);
   const { neverShowClaims, needsSaving } = useSettings();
   const isERC20Dai = isERC20DaiAddress(fromToken);

--- a/packages/react-app/src/components/bridge/FromToken.jsx
+++ b/packages/react-app/src/components/bridge/FromToken.jsx
@@ -12,7 +12,7 @@ import DropDown from 'assets/drop-down.svg';
 import { Logo } from 'components/common/Logo';
 import { SelectTokenModal } from 'components/modals/SelectTokenModal';
 import { BridgeContext } from 'contexts/BridgeContext';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { BigNumber, utils } from 'ethers';
 import { formatValue, logError } from 'lib/helpers';
 import { fetchTokenBalance } from 'lib/token';
@@ -20,7 +20,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { defer } from 'rxjs';
 
 export const FromToken = () => {
-  const { account, providerChainId: chainId } = useContext(Web3Context);
+  const { account, providerChainId: chainId } = useWeb3Context();
   const {
     updateBalance,
     fromToken: token,

--- a/packages/react-app/src/components/bridge/ToToken.jsx
+++ b/packages/react-app/src/components/bridge/ToToken.jsx
@@ -2,7 +2,7 @@ import { Box, Flex, Spinner, Text, useBreakpointValue } from '@chakra-ui/react';
 import { AddToMetamask } from 'components/common/AddToMetamask';
 import { Logo } from 'components/common/Logo';
 import { BridgeContext } from 'contexts/BridgeContext';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { BigNumber, utils } from 'ethers';
 import { formatValue, getBridgeNetwork, logError } from 'lib/helpers';
 import { fetchTokenBalance } from 'lib/token';
@@ -10,7 +10,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { defer } from 'rxjs';
 
 export const ToToken = () => {
-  const { account, providerChainId } = useContext(Web3Context);
+  const { account, providerChainId } = useWeb3Context();
   const {
     updateBalance,
     toToken: token,

--- a/packages/react-app/src/components/bridge/TransferButton.jsx
+++ b/packages/react-app/src/components/bridge/TransferButton.jsx
@@ -3,13 +3,13 @@ import TransferIcon from 'assets/transfer.svg';
 import { ConfirmTransferModal } from 'components/modals/ConfirmTransferModal';
 import { isNativexDaiAddress } from 'components/warnings/ReverseWarning';
 import { BridgeContext } from 'contexts/BridgeContext';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { utils } from 'ethers';
 import { formatValue, isxDaiChain } from 'lib/helpers';
 import React, { useContext } from 'react';
 
 export const TransferButton = () => {
-  const { ethersProvider } = useContext(Web3Context);
+  const { ethersProvider } = useWeb3Context();
   const {
     receiver,
     fromAmount: amount,

--- a/packages/react-app/src/components/bridge/UnlockButton.jsx
+++ b/packages/react-app/src/components/bridge/UnlockButton.jsx
@@ -2,11 +2,11 @@ import { Flex, Image, Spinner, Text, useToast } from '@chakra-ui/react';
 import UnlockIcon from 'assets/unlock.svg';
 import { TxLink } from 'components/common/TxLink';
 import { BridgeContext } from 'contexts/BridgeContext';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import React, { useContext } from 'react';
 
 export const UnlockButton = () => {
-  const { providerChainId } = useContext(Web3Context);
+  const { providerChainId } = useWeb3Context();
   const {
     fromAmount: amount,
     fromBalance: balance,

--- a/packages/react-app/src/components/common/AddToMetamask.jsx
+++ b/packages/react-app/src/components/common/AddToMetamask.jsx
@@ -1,14 +1,14 @@
 import { Image, useDisclosure, useToast } from '@chakra-ui/react';
 import MetamaskFox from 'assets/metamask-fox.svg';
 import { AddToMetamaskModal } from 'components/modals/AddToMetamaskModal';
-import { useWeb3 } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { ADDRESS_ZERO } from 'lib/constants';
 import { getNetworkName, logError } from 'lib/helpers';
 import { addTokenToMetamask } from 'lib/metamask';
 import React from 'react';
 
 export const AddToMetamask = ({ token, asModal = false, ...props }) => {
-  const { providerChainId } = useWeb3();
+  const { providerChainId } = useWeb3Context();
   const toast = useToast();
   const { isOpen, onOpen, onClose } = useDisclosure();
 

--- a/packages/react-app/src/components/common/ConnectWeb3.jsx
+++ b/packages/react-app/src/components/common/ConnectWeb3.jsx
@@ -1,12 +1,12 @@
 import { Button, Flex, Text } from '@chakra-ui/react';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { WalletFilledIcon } from 'icons/WalletFilledIcon';
 import { FOREIGN_CHAIN_ID, HOME_CHAIN_ID } from 'lib/constants';
 import { getNetworkName } from 'lib/helpers';
-import React, { useContext } from 'react';
+import React from 'react';
 
 export const ConnectWeb3 = () => {
-  const { connectWeb3, loading, account, disconnect } = useContext(Web3Context);
+  const { connectWeb3, loading, account, disconnect } = useWeb3Context();
   return (
     <Flex
       background="white"

--- a/packages/react-app/src/components/common/Header.jsx
+++ b/packages/react-app/src/components/common/Header.jsx
@@ -9,14 +9,14 @@ import {
 import Logo from 'assets/logo.svg';
 import { UpdateSettings } from 'components/common/UpdateSettings';
 import { WalletSelector } from 'components/common/WalletSelector';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { HistoryIcon } from 'icons/HistoryIcon';
 import { FOREIGN_CHAIN_ID, HOME_CHAIN_ID } from 'lib/constants';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 export const Header = () => {
-  const { account, providerChainId } = useContext(Web3Context);
+  const { account, providerChainId } = useWeb3Context();
   const [isOpen, setOpen] = useState(false);
   const toggleOpen = () => setOpen(open => !open);
   const valid =

--- a/packages/react-app/src/components/common/Layout.jsx
+++ b/packages/react-app/src/components/common/Layout.jsx
@@ -5,12 +5,12 @@ import { ConnectWeb3 } from 'components/common/ConnectWeb3';
 import { Footer } from 'components/common/Footer';
 import { Header } from 'components/common/Header';
 import { TermsOfServiceModal } from 'components/modals/TermsOfServiceModal';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { FOREIGN_CHAIN_ID, HOME_CHAIN_ID } from 'lib/constants';
-import React, { useContext } from 'react';
+import React from 'react';
 
 export const Layout = ({ children }) => {
-  const { account, providerChainId } = useContext(Web3Context);
+  const { account, providerChainId } = useWeb3Context();
   const valid =
     !!account &&
     [HOME_CHAIN_ID, FOREIGN_CHAIN_ID].indexOf(providerChainId) >= 0;

--- a/packages/react-app/src/components/common/Logo.jsx
+++ b/packages/react-app/src/components/common/Logo.jsx
@@ -2,9 +2,9 @@ import { Image } from '@chakra-ui/react';
 import BSCLogo from 'assets/bsc-logo.png';
 import EthLogo from 'assets/eth-logo.png';
 import xDAILogo from 'assets/xdai-logo.png';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { getBridgeNetwork, uriToHttp } from 'lib/helpers';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 
 const BAD_SRCS = {};
 
@@ -20,7 +20,7 @@ const logos = {
  * Renders an image by sequentially trying a list of URIs, and then eventually a fallback triangle alert
  */
 export const Logo = ({ uri, reverseFallback = false }) => {
-  const { providerChainId } = useContext(Web3Context);
+  const { providerChainId } = useWeb3Context();
   const chainId = reverseFallback
     ? getBridgeNetwork(providerChainId)
     : providerChainId;

--- a/packages/react-app/src/components/common/WalletSelector.jsx
+++ b/packages/react-app/src/components/common/WalletSelector.jsx
@@ -8,13 +8,13 @@ import {
   Text,
   useBreakpointValue,
 } from '@chakra-ui/react';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { WalletIcon } from 'icons/WalletIcon';
 import { getAccountString, getNetworkLabel, getNetworkName } from 'lib/helpers';
-import React, { useContext } from 'react';
+import React from 'react';
 
 export const WalletSelector = ({ close }) => {
-  const { disconnect, account, providerChainId } = useContext(Web3Context);
+  const { disconnect, account, providerChainId } = useWeb3Context();
 
   const placement = useBreakpointValue({ base: 'bottom', md: 'bottom-end' });
   return (

--- a/packages/react-app/src/components/history/HistoryItem.jsx
+++ b/packages/react-app/src/components/history/HistoryItem.jsx
@@ -11,7 +11,7 @@ import BlueTickImage from 'assets/blue-tick.svg';
 import RightArrowImage from 'assets/right-arrow.svg';
 import { AddToMetamask } from 'components/common/AddToMetamask';
 import { TxLink } from 'components/common/TxLink';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { BigNumber, utils } from 'ethers';
 import {
   executeSignatures,
@@ -27,7 +27,7 @@ import {
   isxDaiChain,
   logError,
 } from 'lib/helpers';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 const { formatUnits } = utils;
 
@@ -72,7 +72,7 @@ export const HistoryItem = ({
     message: inputMessage,
   },
 }) => {
-  const { providerChainId, ethersProvider } = useContext(Web3Context);
+  const { providerChainId, ethersProvider } = useWeb3Context();
   const bridgeChainId = getBridgeNetwork(chainId);
   const [receivingTx, setReceiving] = useState(inputReceivingTx);
   const [message, setMessage] = useState(inputMessage);

--- a/packages/react-app/src/components/modals/AddToMetamaskModal.jsx
+++ b/packages/react-app/src/components/modals/AddToMetamaskModal.jsx
@@ -21,7 +21,7 @@ import {
 } from '@chakra-ui/react';
 import ErrorImage from 'assets/error.svg';
 import MetamaskFox from 'assets/metamask-fox.svg';
-import { useWeb3 } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { useCopyToClipboard } from 'hooks/useCopyToClipboard';
 import { getAccountString, getNetworkName, logError } from 'lib/helpers';
 import { addTokenToMetamask } from 'lib/metamask';
@@ -29,7 +29,7 @@ import React, { useState } from 'react';
 
 export const AddToMetamaskModal = ({ isOpen, onClose, token: tokenToAdd }) => {
   const [token] = useState(tokenToAdd);
-  const { providerChainId } = useWeb3();
+  const { providerChainId } = useWeb3Context();
   const needsNetworkChange = token.chainId !== providerChainId;
   const [loading, setLoading] = useState(false);
   const [copied, handleCopy] = useCopyToClipboard();

--- a/packages/react-app/src/components/modals/ClaimTokensModal.jsx
+++ b/packages/react-app/src/components/modals/ClaimTokensModal.jsx
@@ -14,16 +14,16 @@ import {
 } from '@chakra-ui/react';
 import ClaimTokensImage from 'assets/multiple-claim.svg';
 import { LoadingModal } from 'components/modals/LoadingModal';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { useClaimableTransfers } from 'hooks/useClaimableTransfers';
 import { LOCAL_STORAGE_KEYS } from 'lib/constants';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 const { DONT_SHOW_CLAIMS } = LOCAL_STORAGE_KEYS;
 
 export const ClaimTokensModal = () => {
-  const { account, providerChainId } = useContext(Web3Context);
+  const { account, providerChainId } = useWeb3Context();
   const { transfers, loading } = useClaimableTransfers();
   const [isOpen, setOpen] = useState(false);
 

--- a/packages/react-app/src/components/modals/ClaimTransferModal.jsx
+++ b/packages/react-app/src/components/modals/ClaimTransferModal.jsx
@@ -17,7 +17,7 @@ import ErrorImage from 'assets/error.svg';
 import InfoImage from 'assets/info.svg';
 import { LoadingModal } from 'components/modals/LoadingModal';
 import { BridgeContext } from 'contexts/BridgeContext';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import {
   executeSignatures,
   getMessageFromTxHash,
@@ -32,7 +32,7 @@ import { getNetworkName, logError } from 'lib/helpers';
 import React, { useContext, useEffect, useState } from 'react';
 
 export const ClaimTransferModal = () => {
-  const { account, ethersProvider, providerChainId } = useContext(Web3Context);
+  const { account, ethersProvider, providerChainId } = useWeb3Context();
   const { txHash, setTxHash } = useContext(BridgeContext);
   const [isOpen, setOpen] = useState(false);
   const [claiming, setClaiming] = useState(false);

--- a/packages/react-app/src/components/modals/CustomTokenModal.jsx
+++ b/packages/react-app/src/components/modals/CustomTokenModal.jsx
@@ -15,7 +15,7 @@ import {
 } from '@chakra-ui/react';
 import CustomTokenImage from 'assets/custom-token.svg';
 import { BridgeContext } from 'contexts/BridgeContext';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { utils } from 'ethers';
 import { LOCAL_STORAGE_KEYS } from 'lib/constants';
 import { logError, uniqueTokens } from 'lib/helpers';
@@ -26,7 +26,7 @@ const { CUSTOM_TOKENS } = LOCAL_STORAGE_KEYS;
 
 export const CustomTokenModal = ({ isOpen, onClose, onBack }) => {
   const { setToken } = useContext(BridgeContext);
-  const { providerChainId } = useContext(Web3Context);
+  const { providerChainId } = useWeb3Context();
   const [customToken, setCustomToken] = useState({
     address: '',
     name: '',

--- a/packages/react-app/src/components/modals/LoadingModal.jsx
+++ b/packages/react-app/src/components/modals/LoadingModal.jsx
@@ -12,7 +12,7 @@ import BlueTickImage from 'assets/blue-tick.svg';
 import LoadingImage from 'assets/loading.svg';
 import { ProgressRing } from 'components/common/ProgressRing';
 import { BridgeContext } from 'contexts/BridgeContext';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { getMonitorUrl } from 'lib/helpers';
 import React, { useContext } from 'react';
 
@@ -23,7 +23,7 @@ const getTransactionString = hash => {
 };
 
 export const LoadingModal = ({ loadingText, txHash, chainId }) => {
-  const { providerChainId } = useContext(Web3Context);
+  const { providerChainId } = useWeb3Context();
   const { loading } = useContext(BridgeContext);
   return (
     <Modal

--- a/packages/react-app/src/components/modals/TokenSelectorModal.jsx
+++ b/packages/react-app/src/components/modals/TokenSelectorModal.jsx
@@ -19,7 +19,7 @@ import {
 import SearchIcon from 'assets/search.svg';
 import { Logo } from 'components/common/Logo';
 import { BridgeContext } from 'contexts/BridgeContext';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { PlusIcon } from 'icons/PlusIcon';
 import { formatValue, logError, uniqueTokens } from 'lib/helpers';
 import { fetchTokenBalanceWithProvider } from 'lib/token';
@@ -33,7 +33,7 @@ import React, {
 } from 'react';
 
 export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
-  const { account, ethersProvider, providerChainId } = useContext(Web3Context);
+  const { account, ethersProvider, providerChainId } = useWeb3Context();
   const { setToken } = useContext(BridgeContext);
   const [tokenList, setTokenList] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/packages/react-app/src/contexts/BridgeContext.jsx
+++ b/packages/react-app/src/contexts/BridgeContext.jsx
@@ -1,5 +1,5 @@
 import { useToast } from '@chakra-ui/react';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { BigNumber } from 'ethers';
 import { useApproval } from 'hooks/useApproval';
 import { useCurrentDay } from 'hooks/useCurrentDay';
@@ -21,12 +21,12 @@ import {
   parseValue,
 } from 'lib/helpers';
 import { fetchTokenDetails } from 'lib/token';
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 export const BridgeContext = React.createContext({});
 
 export const BridgeProvider = ({ children }) => {
-  const { ethersProvider, account, providerChainId } = useContext(Web3Context);
+  const { ethersProvider, account, providerChainId } = useWeb3Context();
 
   const [receiver, setReceiver] = useState('');
   const [{ fromToken, toToken }, setTokens] = useState({});

--- a/packages/react-app/src/contexts/Web3Context.jsx
+++ b/packages/react-app/src/contexts/Web3Context.jsx
@@ -109,7 +109,6 @@ export const Web3Provider = ({ children }) => {
   }, []);
 
   useEffect(() => {
-    console.log(web3Modal);
     if (window.ethereum) {
       window.ethereum.autoRefreshOnNetworkChange = false;
     }

--- a/packages/react-app/src/contexts/Web3Context.jsx
+++ b/packages/react-app/src/contexts/Web3Context.jsx
@@ -6,7 +6,7 @@ import Web3 from 'web3';
 import Web3Modal from 'web3modal';
 
 export const Web3Context = React.createContext({});
-export const useWeb3 = () => useContext(Web3Context);
+export const useWeb3Context = () => useContext(Web3Context);
 
 const updateTitle = chainId => {
   const networkName = getNetworkName(chainId);
@@ -109,6 +109,7 @@ export const Web3Provider = ({ children }) => {
   }, []);
 
   useEffect(() => {
+    console.log(web3Modal);
     if (window.ethereum) {
       window.ethereum.autoRefreshOnNetworkChange = false;
     }

--- a/packages/react-app/src/hooks/useApproval.js
+++ b/packages/react-app/src/hooks/useApproval.js
@@ -1,14 +1,14 @@
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { BigNumber } from 'ethers';
 import { LARGEST_UINT256, LOCAL_STORAGE_KEYS } from 'lib/constants';
 import { logError } from 'lib/helpers';
 import { approveToken, fetchAllowance } from 'lib/token';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 const { INFINITE_UNLOCK } = LOCAL_STORAGE_KEYS;
 
 export const useApproval = (fromToken, fromAmount) => {
-  const { account, ethersProvider, providerChainId } = useContext(Web3Context);
+  const { account, ethersProvider, providerChainId } = useWeb3Context();
   const [allowance, setAllowance] = useState(BigNumber.from(0));
   const [trigger, shouldTrigger] = useState(false);
   const updateAllowance = () => shouldTrigger(u => !u);

--- a/packages/react-app/src/hooks/useClaimableTransfers.js
+++ b/packages/react-app/src/hooks/useClaimableTransfers.js
@@ -1,5 +1,5 @@
 import { BridgeContext } from 'contexts/BridgeContext';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { FOREIGN_CHAIN_ID, HOME_CHAIN_ID } from 'lib/constants';
 import {
   combineRequestsWithExecutions,
@@ -10,7 +10,7 @@ import { useContext, useEffect, useState } from 'react';
 import { defer } from 'rxjs';
 
 export const useClaimableTransfers = () => {
-  const { account, providerChainId } = useContext(Web3Context);
+  const { account, providerChainId } = useWeb3Context();
   const { txHash } = useContext(BridgeContext);
   const [transfers, setTransfers] = useState();
   const [loading, setLoading] = useState(false);

--- a/packages/react-app/src/hooks/useCurrentDay.js
+++ b/packages/react-app/src/hooks/useCurrentDay.js
@@ -1,10 +1,10 @@
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { Contract } from 'ethers';
 import { getMediatorAddress, logError } from 'lib/helpers';
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export const useCurrentDay = () => {
-  const { ethersProvider, providerChainId: chainId } = useContext(Web3Context);
+  const { ethersProvider, providerChainId: chainId } = useWeb3Context();
   const [currentDay, setCurrentDay] = useState();
 
   useEffect(() => {

--- a/packages/react-app/src/hooks/useGraphHealth.js
+++ b/packages/react-app/src/hooks/useGraphHealth.js
@@ -1,10 +1,10 @@
 import { useToast } from '@chakra-ui/react';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { FOREIGN_CHAIN_ID, HOME_CHAIN_ID } from 'lib/constants';
 import { getHealthStatus } from 'lib/graphHealth';
 import { logDebug, logError } from 'lib/helpers';
 import { getEthersProvider } from 'lib/providers';
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { defer } from 'rxjs';
 
 const {
@@ -25,7 +25,7 @@ const THRESHOLD_BLOCKS =
   DEFAULT_GRAPH_HEALTH_THRESHOLD_BLOCKS;
 
 export const useGraphHealth = (description, onlyHome = false) => {
-  const { providerChainId } = useContext(Web3Context);
+  const { providerChainId } = useWeb3Context();
 
   const isHome = providerChainId === HOME_CHAIN_ID;
 

--- a/packages/react-app/src/hooks/useRewardAddress.js
+++ b/packages/react-app/src/hooks/useRewardAddress.js
@@ -1,12 +1,12 @@
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { Contract } from 'ethers';
 import { HOME_CHAIN_ID } from 'lib/constants';
 import { getMediatorAddress, logError } from 'lib/helpers';
 import { getEthersProvider } from 'lib/providers';
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export const useRewardAddress = () => {
-  const { account } = useContext(Web3Context);
+  const { account } = useWeb3Context();
   const [isRewardAddress, setRewardAddress] = useState(false);
 
   useEffect(() => {

--- a/packages/react-app/src/hooks/useTotalConfirms.js
+++ b/packages/react-app/src/hooks/useTotalConfirms.js
@@ -1,10 +1,10 @@
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { fetchConfirmations } from 'lib/amb';
 import { logError } from 'lib/helpers';
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export const useTotalConfirms = () => {
-  const { providerChainId, ethersProvider } = useContext(Web3Context);
+  const { providerChainId, ethersProvider } = useWeb3Context();
   const [totalConfirms, setTotalConfirms] = useState(8);
 
   useEffect(() => {

--- a/packages/react-app/src/hooks/useTransactionStatus.js
+++ b/packages/react-app/src/hooks/useTransactionStatus.js
@@ -1,5 +1,5 @@
 import { BridgeContext } from 'contexts/BridgeContext';
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { getMessageFromTxHash, getMessageStatus } from 'lib/amb';
 import { POLLING_INTERVAL } from 'lib/constants';
 import { getBridgeNetwork, isxDaiChain, logError } from 'lib/helpers';
@@ -7,7 +7,7 @@ import { useCallback, useContext, useEffect, useState } from 'react';
 import { defer } from 'rxjs';
 
 export const useTransactionStatus = () => {
-  const { ethersProvider, providerChainId } = useContext(Web3Context);
+  const { ethersProvider, providerChainId } = useWeb3Context();
   const {
     loading,
     setLoading,

--- a/packages/react-app/src/hooks/useUserHistory.js
+++ b/packages/react-app/src/hooks/useUserHistory.js
@@ -1,15 +1,15 @@
-import { Web3Context } from 'contexts/Web3Context';
+import { useWeb3Context } from 'contexts/Web3Context';
 import { FOREIGN_CHAIN_ID, HOME_CHAIN_ID } from 'lib/constants';
 import {
   combineRequestsWithExecutions,
   getExecutions,
   getRequests,
 } from 'lib/history';
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { defer } from 'rxjs';
 
 export const useUserHistory = () => {
-  const { account } = useContext(Web3Context);
+  const { account } = useWeb3Context();
   const [transfers, setTransfers] = useState();
   const [loading, setLoading] = useState(true);
   const chainId = HOME_CHAIN_ID;


### PR DESCRIPTION
I have seen a function naming useWeb3Context over `Web3Context.jsx` but not being completely used over some of the files. Hence I just made sure to do it as a chore and replace useContext(WebContext) with useWeb3Context() for better readability @dan13ram.