### PR TITLE
feat: add a toggle to fetch token list without balance

### DIFF
--- a/packages/react-app/src/components/common/UpdateSettings.jsx
+++ b/packages/react-app/src/components/common/UpdateSettings.jsx
@@ -35,6 +35,7 @@ export const UpdateSettings = ({ close }) => {
     setNeverShowClaims,
     disableBalanceFetchToken,
     setDisableBalanceFetchToken,
+    needsSaving,
     save,
   } = useSettings();
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -150,6 +151,7 @@ export const UpdateSettings = ({ close }) => {
                   colorScheme="blue"
                   mt={{ base: 2, md: 0 }}
                   ref={initialRef}
+                  disabled={!needsSaving}
                   w="100%"
                 >
                   Save

--- a/packages/react-app/src/components/common/UpdateSettings.jsx
+++ b/packages/react-app/src/components/common/UpdateSettings.jsx
@@ -35,9 +35,7 @@ export const UpdateSettings = ({ close }) => {
     setNeverShowClaims,
     disableBalanceFetchToken,
     setDisableBalanceFetchToken,
-    update,
     save,
-    needsSaving,
   } = useSettings();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -48,9 +46,8 @@ export const UpdateSettings = ({ close }) => {
 
   const openSettings = useCallback(() => {
     close();
-    update();
     onOpen();
-  }, [close, update, onOpen]);
+  }, [close, onOpen]);
 
   return (
     <>
@@ -152,7 +149,6 @@ export const UpdateSettings = ({ close }) => {
                   onClick={onSave}
                   colorScheme="blue"
                   mt={{ base: 2, md: 0 }}
-                  isDisabled={!needsSaving}
                   ref={initialRef}
                   w="100%"
                 >

--- a/packages/react-app/src/components/common/UpdateSettings.jsx
+++ b/packages/react-app/src/components/common/UpdateSettings.jsx
@@ -33,8 +33,8 @@ export const UpdateSettings = ({ close }) => {
     setInfiniteUnlock,
     neverShowClaims,
     setNeverShowClaims,
-    tokenListWithBalance,
-    setTokenListWithBalance,
+    disableBalanceFetchToken,
+    setDisableBalanceFetchToken,
     update,
     save,
     needsSaving,
@@ -131,12 +131,12 @@ export const UpdateSettings = ({ close }) => {
                   isChecked={neverShowClaims}
                   onChange={e => setNeverShowClaims(e.target.checked)}
                 />
-                <Text mb={2}>Fetch token list with balance</Text>
+                <Text mb={2}>Disable balances in token list</Text>
                 <Switch
                   mb={4}
                   colorScheme="blue"
-                  isChecked={tokenListWithBalance}
-                  onChange={e => setTokenListWithBalance(e.target.checked)}
+                  isChecked={disableBalanceFetchToken}
+                  onChange={e => setDisableBalanceFetchToken(e.target.checked)}
                 />
               </Flex>
             </ModalBody>

--- a/packages/react-app/src/components/common/UpdateSettings.jsx
+++ b/packages/react-app/src/components/common/UpdateSettings.jsx
@@ -33,6 +33,8 @@ export const UpdateSettings = ({ close }) => {
     setInfiniteUnlock,
     neverShowClaims,
     setNeverShowClaims,
+    tokenListWithBalance,
+    setTokenListWithBalance,
     update,
     save,
     needsSaving,
@@ -128,6 +130,13 @@ export const UpdateSettings = ({ close }) => {
                   colorScheme="blue"
                   isChecked={neverShowClaims}
                   onChange={e => setNeverShowClaims(e.target.checked)}
+                />
+                <Text mb={2}>Fetch token list with balance</Text>
+                <Switch
+                  mb={4}
+                  colorScheme="blue"
+                  isChecked={tokenListWithBalance}
+                  onChange={e => setTokenListWithBalance(e.target.checked)}
                 />
               </Flex>
             </ModalBody>

--- a/packages/react-app/src/components/modals/TokenSelectorModal.jsx
+++ b/packages/react-app/src/components/modals/TokenSelectorModal.jsx
@@ -19,6 +19,7 @@ import {
 import SearchIcon from 'assets/search.svg';
 import { Logo } from 'components/common/Logo';
 import { BridgeContext } from 'contexts/BridgeContext';
+import { useSettings } from 'contexts/SettingsContext';
 import { useWeb3Context } from 'contexts/Web3Context';
 import { PlusIcon } from 'icons/PlusIcon';
 import { formatValue, logError, uniqueTokens } from 'lib/helpers';
@@ -33,10 +34,39 @@ import React, {
 } from 'react';
 
 export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
-  const { account, ethersProvider, providerChainId } = useWeb3Context();
+  // Ref
+  const initialRef = useRef();
+  // Contexts
   const { setToken } = useContext(BridgeContext);
-  const [tokenList, setTokenList] = useState([]);
+  const { account, ethersProvider, providerChainId } = useWeb3Context();
+  const { tokenListWithBalance: tokenBalanceToggle } = useSettings();
+  // State
   const [loading, setLoading] = useState(true);
+  const [tokenList, setTokenList] = useState([]);
+  const [filteredTokenList, setFilteredTokenList] = useState([]);
+  const smallScreen = useBreakpointValue({ sm: false, base: true });
+
+  // Callbacks
+  const fetchTokenListWithBalance = useCallback(
+    async tList => {
+      const tokenListWithBalance = await Promise.all(
+        tList.map(async token => ({
+          ...token,
+          balance: await fetchTokenBalanceWithProvider(
+            ethersProvider,
+            token,
+            account,
+          ),
+        })),
+      );
+
+      return tokenListWithBalance.sort(
+        ({ balance: balanceA }, { balance: balanceB }) =>
+          balanceB.sub(balanceA).gt(0) ? 1 : -1,
+      );
+    },
+    [account, ethersProvider],
+  );
 
   const setDefaultTokenList = useCallback(
     async (chainId, customTokens) => {
@@ -48,77 +78,52 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
             customTokens.filter(token => token.chainId === chainId),
           ),
         );
-        const tokenListWithBalance = await Promise.all(
-          customTokenList.map(async token => ({
-            ...token,
-            balance: await fetchTokenBalanceWithProvider(
-              ethersProvider,
-              token,
-              account,
-            ),
-          })),
+        setTokenList(
+          tokenBalanceToggle
+            ? await fetchTokenListWithBalance(customTokenList)
+            : customTokenList,
         );
-        const sortedTokenList = tokenListWithBalance.sort(function checkBalance(
-          { balance: balanceA },
-          { balance: balanceB },
-        ) {
-          if (balanceB.sub(balanceA).gt(0)) {
-            return 1;
-          }
-          return -1;
-        });
-        setTokenList(sortedTokenList);
       } catch (fetchTokensError) {
         logError({ fetchTokensError });
       }
       setLoading(false);
     },
-    [account, ethersProvider],
+    [fetchTokenListWithBalance, tokenBalanceToggle],
   );
 
-  const [filteredTokenList, setFilteredTokenList] = useState([]);
+  // Effects
+  useEffect(() => {
+    tokenList.length && setFilteredTokenList(tokenList);
+  }, [tokenList, setFilteredTokenList]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    let localTokenList = window.localStorage.getItem('customTokens');
+    localTokenList =
+      !localTokenList || !localTokenList.length
+        ? []
+        : JSON.parse(localTokenList);
+    providerChainId && setDefaultTokenList(providerChainId, localTokenList);
+  }, [isOpen, providerChainId, setDefaultTokenList]);
+
+  // Handlers
   const onClick = token => {
     setToken(token);
     onClose();
   };
 
-  const initialRef = useRef();
-
   const onChange = e => {
     const newFilteredTokenList = tokenList.filter(token => {
       const lowercaseSearch = e.target.value.toLowerCase();
+      const { name, symbol, address } = token;
       return (
-        token.name.toLowerCase().includes(lowercaseSearch) ||
-        token.symbol.toLowerCase().includes(lowercaseSearch) ||
-        token.address.toLowerCase().includes(lowercaseSearch)
+        name.toLowerCase().includes(lowercaseSearch) ||
+        symbol.toLowerCase().includes(lowercaseSearch) ||
+        address.toLowerCase().includes(lowercaseSearch)
       );
     });
     setFilteredTokenList(newFilteredTokenList);
   };
-
-  useEffect(() => {
-    setFilteredTokenList(tokenList);
-  }, [tokenList, setFilteredTokenList]);
-
-  useEffect(() => {
-    let localTokenList = window.localStorage.getItem('customTokens');
-    if (!localTokenList) {
-      localTokenList = [];
-    }
-    if (localTokenList.length < 1) {
-      localTokenList = [];
-    } else {
-      localTokenList = JSON.parse(localTokenList);
-    }
-
-    if (!isOpen) return;
-    if (providerChainId) {
-      setDefaultTokenList(providerChainId, localTokenList);
-    }
-  }, [isOpen, providerChainId, setDefaultTokenList]);
-
-  const smallScreen = useBreakpointValue({ sm: false, base: true });
 
   return (
     <Modal
@@ -214,9 +219,11 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
                         {token.symbol}
                       </Text>
                     </Flex>
-                    <Text color="grey" fontWeight="normal">
-                      {formatValue(token.balance, token.decimals)}
-                    </Text>
+                    {tokenBalanceToggle && token.balance && token.decimals && (
+                      <Text color="grey" fontWeight="normal">
+                        {formatValue(token.balance, token.decimals)}
+                      </Text>
+                    )}
                   </Flex>
                 </Button>
               ))}

--- a/packages/react-app/src/components/modals/TokenSelectorModal.jsx
+++ b/packages/react-app/src/components/modals/TokenSelectorModal.jsx
@@ -39,7 +39,7 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
   // Contexts
   const { setToken } = useContext(BridgeContext);
   const { account, ethersProvider, providerChainId } = useWeb3Context();
-  const { tokenListWithBalance: tokenBalanceToggle } = useSettings();
+  const { disableBalanceFetchToken } = useSettings();
   // State
   const [loading, setLoading] = useState(true);
   const [tokenList, setTokenList] = useState([]);
@@ -79,7 +79,7 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
           ),
         );
         setTokenList(
-          tokenBalanceToggle
+          !disableBalanceFetchToken
             ? await fetchTokenListWithBalance(customTokenList)
             : customTokenList,
         );
@@ -88,7 +88,7 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
       }
       setLoading(false);
     },
-    [fetchTokenListWithBalance, tokenBalanceToggle],
+    [fetchTokenListWithBalance, disableBalanceFetchToken],
   );
 
   // Effects
@@ -219,11 +219,13 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
                         {token.symbol}
                       </Text>
                     </Flex>
-                    {tokenBalanceToggle && token.balance && token.decimals && (
-                      <Text color="grey" fontWeight="normal">
-                        {formatValue(token.balance, token.decimals)}
-                      </Text>
-                    )}
+                    {disableBalanceFetchToken &&
+                      token.balance &&
+                      token.decimals && (
+                        <Text color="grey" fontWeight="normal">
+                          {formatValue(token.balance, token.decimals)}
+                        </Text>
+                      )}
                   </Flex>
                 </Button>
               ))}

--- a/packages/react-app/src/components/modals/TokenSelectorModal.jsx
+++ b/packages/react-app/src/components/modals/TokenSelectorModal.jsx
@@ -191,44 +191,52 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
               </Flex>
             )}
             {!loading &&
-              filteredTokenList.map(token => (
-                <Button
-                  variant="outline"
-                  size="lg"
-                  width="100%"
-                  borderColor="#DAE3F0"
-                  key={token.address}
-                  onClick={() => onClick(token)}
-                  mb={2}
-                  px={4}
-                >
-                  <Flex align="center" width="100%" justify="space-between">
-                    <Flex align="center">
-                      <Flex
-                        justify="center"
-                        align="center"
-                        background="white"
-                        border="1px solid #DAE3F0"
-                        boxSize={8}
-                        overflow="hidden"
-                        borderRadius="50%"
-                      >
-                        <Logo uri={token.logoURI} />
+              filteredTokenList.map(token => {
+                const {
+                  decimals,
+                  balance,
+                  name,
+                  address,
+                  logoURI,
+                  symbol,
+                } = token;
+                return (
+                  <Button
+                    variant="outline"
+                    size="lg"
+                    width="100%"
+                    borderColor="#DAE3F0"
+                    key={address}
+                    onClick={() => onClick(token)}
+                    mb={2}
+                    px={4}
+                  >
+                    <Flex align="center" width="100%" justify="space-between">
+                      <Flex align="center">
+                        <Flex
+                          justify="center"
+                          align="center"
+                          background="white"
+                          border="1px solid #DAE3F0"
+                          boxSize={8}
+                          overflow="hidden"
+                          borderRadius="50%"
+                        >
+                          <Logo uri={logoURI} />
+                        </Flex>
+                        <Text fontSize="lg" fontWeight="bold" mx={2}>
+                          {symbol}
+                        </Text>
                       </Flex>
-                      <Text fontSize="lg" fontWeight="bold" mx={2}>
-                        {token.symbol}
+                      <Text color="grey" fontWeight="normal">
+                        {disableBalanceFetchToken && balance && decimals
+                          ? formatValue(balance, decimals)
+                          : name}
                       </Text>
                     </Flex>
-                    {disableBalanceFetchToken &&
-                      token.balance &&
-                      token.decimals && (
-                        <Text color="grey" fontWeight="normal">
-                          {formatValue(token.balance, token.decimals)}
-                        </Text>
-                      )}
-                  </Flex>
-                </Button>
-              ))}
+                  </Button>
+                );
+              })}
           </ModalBody>
         </ModalContent>
       </ModalOverlay>

--- a/packages/react-app/src/components/modals/TokenSelectorModal.jsx
+++ b/packages/react-app/src/components/modals/TokenSelectorModal.jsx
@@ -229,7 +229,7 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
                         </Text>
                       </Flex>
                       <Text color="grey" fontWeight="normal">
-                        {disableBalanceFetchToken && balance && decimals
+                        {!disableBalanceFetchToken && balance && decimals
                           ? formatValue(balance, decimals)
                           : name}
                       </Text>

--- a/packages/react-app/src/components/modals/TokenSelectorModal.jsx
+++ b/packages/react-app/src/components/modals/TokenSelectorModal.jsx
@@ -228,7 +228,13 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
                           {symbol}
                         </Text>
                       </Flex>
-                      <Text color="grey" fontWeight="normal">
+                      <Text
+                        color="grey"
+                        fontWeight="normal"
+                        textOverflow="ellipsis"
+                        overflow="hidden"
+                        maxWidth="60%"
+                      >
                         {!disableBalanceFetchToken && balance && decimals
                           ? formatValue(balance, decimals)
                           : name}

--- a/packages/react-app/src/contexts/SettingsContext.jsx
+++ b/packages/react-app/src/contexts/SettingsContext.jsx
@@ -1,6 +1,6 @@
 import { useLocalState } from 'hooks/useLocalState';
 import { LOCAL_STORAGE_KEYS } from 'lib/constants';
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 const {
   INFINITE_UNLOCK,
@@ -19,25 +19,64 @@ export const SettingsProvider = ({ children }) => {
   const [neverShowClaims, setNeverShowClaims] = useLocalState(
     false,
     NEVER_SHOW_CLAIMS,
-    'boolean',
+    { valueType: 'boolean' },
   );
+
   const [infiniteUnlock, setInfiniteUnlock] = useLocalState(
     false,
     INFINITE_UNLOCK,
-    'boolean',
+    { valueType: 'boolean' },
   );
+
   const [disableBalanceFetchToken, setDisableBalanceFetchToken] = useLocalState(
     false,
     DISABLE_BALANCE_WHILE_TOKEN_FETCH,
-    'boolean',
+    {
+      valueType: 'boolean',
+    },
   );
 
+  const [needsSaving, setNeedsSaving] = useState(false);
+
   const save = useCallback(() => {
-    setMainnetRPC(mRPC => mRPC);
-    setXDaiRPC(xRPC => xRPC);
-    setNeverShowClaims(nClaims => nClaims);
-    setInfiniteUnlock(iUnlock => iUnlock);
-  }, [setInfiniteUnlock, setMainnetRPC, setXDaiRPC, setNeverShowClaims]);
+    if (needsSaving) {
+      setMainnetRPC(mRPC => mRPC, true);
+      setXDaiRPC(xRPC => xRPC, true);
+      setNeverShowClaims(nClaims => nClaims, true);
+      setInfiniteUnlock(iUnlock => iUnlock, true);
+      setDisableBalanceFetchToken(dBalanceToken => dBalanceToken, true);
+      setNeedsSaving(false);
+    }
+  }, [
+    setInfiniteUnlock,
+    setDisableBalanceFetchToken,
+    setMainnetRPC,
+    setXDaiRPC,
+    setNeverShowClaims,
+    needsSaving,
+  ]);
+
+  useEffect(() => {
+    if (
+      window.localStorage.getItem(XDAI_RPC_URL) !== xdaiRPC ||
+      window.localStorage.getItem(MAINNET_RPC_URL) !== mainnetRPC ||
+      window.localStorage.getItem(NEVER_SHOW_CLAIMS) !==
+        neverShowClaims.toString() ||
+      window.localStorage.getItem(INFINITE_UNLOCK) !==
+        infiniteUnlock.toString() ||
+      window.localStorage.getItem(DISABLE_BALANCE_WHILE_TOKEN_FETCH) !==
+        disableBalanceFetchToken.toString()
+    ) {
+      console.log('UPDATE HAPPENED');
+      setNeedsSaving(true);
+    }
+  }, [
+    mainnetRPC,
+    xdaiRPC,
+    neverShowClaims,
+    infiniteUnlock,
+    disableBalanceFetchToken,
+  ]);
 
   return (
     <SettingsContext.Provider
@@ -52,6 +91,8 @@ export const SettingsProvider = ({ children }) => {
         setNeverShowClaims,
         disableBalanceFetchToken,
         setDisableBalanceFetchToken,
+        needsSaving,
+        setNeedsSaving,
         save,
       }}
     >

--- a/packages/react-app/src/contexts/SettingsContext.jsx
+++ b/packages/react-app/src/contexts/SettingsContext.jsx
@@ -1,3 +1,4 @@
+import { useLocalState } from 'hooks/useLocalState';
 import { LOCAL_STORAGE_KEYS } from 'lib/constants';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 
@@ -15,7 +16,10 @@ export const SettingsProvider = ({ children }) => {
   const [xdaiRPC, setXDaiRPC] = useState('');
   const [neverShowClaims, setNeverShowClaims] = useState(false);
   const [infiniteUnlock, setInfiniteUnlock] = useState(false);
-  const [tokenListWithBalance, setTokenListWithBalance] = useState(false);
+  const [disableBalanceFetchToken, setDisableBalanceFetchToken] = useLocalState(
+    false,
+    'disable-balance-while-token-fetch',
+  );
 
   const [trigger, shouldTrigger] = useState(false);
 
@@ -66,8 +70,8 @@ export const SettingsProvider = ({ children }) => {
         setInfiniteUnlock,
         neverShowClaims,
         setNeverShowClaims,
-        tokenListWithBalance,
-        setTokenListWithBalance,
+        disableBalanceFetchToken,
+        setDisableBalanceFetchToken,
         update,
         save,
         needsSaving,

--- a/packages/react-app/src/contexts/SettingsContext.jsx
+++ b/packages/react-app/src/contexts/SettingsContext.jsx
@@ -19,6 +19,7 @@ export const SettingsProvider = ({ children }) => {
   const [disableBalanceFetchToken, setDisableBalanceFetchToken] = useLocalState(
     false,
     'disable-balance-while-token-fetch',
+    'boolean',
   );
 
   const [trigger, shouldTrigger] = useState(false);

--- a/packages/react-app/src/contexts/SettingsContext.jsx
+++ b/packages/react-app/src/contexts/SettingsContext.jsx
@@ -15,6 +15,7 @@ export const SettingsProvider = ({ children }) => {
   const [xdaiRPC, setXDaiRPC] = useState('');
   const [neverShowClaims, setNeverShowClaims] = useState(false);
   const [infiniteUnlock, setInfiniteUnlock] = useState(false);
+  const [tokenListWithBalance, setTokenListWithBalance] = useState(false);
 
   const [trigger, shouldTrigger] = useState(false);
 
@@ -65,6 +66,8 @@ export const SettingsProvider = ({ children }) => {
         setInfiniteUnlock,
         neverShowClaims,
         setNeverShowClaims,
+        tokenListWithBalance,
+        setTokenListWithBalance,
         update,
         save,
         needsSaving,

--- a/packages/react-app/src/contexts/SettingsContext.jsx
+++ b/packages/react-app/src/contexts/SettingsContext.jsx
@@ -1,64 +1,43 @@
 import { useLocalState } from 'hooks/useLocalState';
 import { LOCAL_STORAGE_KEYS } from 'lib/constants';
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext } from 'react';
 
 const {
   INFINITE_UNLOCK,
   MAINNET_RPC_URL,
   XDAI_RPC_URL,
   NEVER_SHOW_CLAIMS,
+  DISABLE_BALANCE_WHILE_TOKEN_FETCH,
 } = LOCAL_STORAGE_KEYS;
 
 const SettingsContext = React.createContext({});
 
 export const SettingsProvider = ({ children }) => {
-  const [mainnetRPC, setMainnetRPC] = useState('');
-  const [xdaiRPC, setXDaiRPC] = useState('');
-  const [neverShowClaims, setNeverShowClaims] = useState(false);
-  const [infiniteUnlock, setInfiniteUnlock] = useState(false);
+  const [mainnetRPC, setMainnetRPC] = useLocalState('', MAINNET_RPC_URL);
+  const [xdaiRPC, setXDaiRPC] = useLocalState('', XDAI_RPC_URL);
+
+  const [neverShowClaims, setNeverShowClaims] = useLocalState(
+    false,
+    NEVER_SHOW_CLAIMS,
+    'boolean',
+  );
+  const [infiniteUnlock, setInfiniteUnlock] = useLocalState(
+    false,
+    INFINITE_UNLOCK,
+    'boolean',
+  );
   const [disableBalanceFetchToken, setDisableBalanceFetchToken] = useLocalState(
     false,
-    'disable-balance-while-token-fetch',
+    DISABLE_BALANCE_WHILE_TOKEN_FETCH,
     'boolean',
   );
 
-  const [trigger, shouldTrigger] = useState(false);
-
-  const [needsSaving, setNeedsSaving] = useState(false);
-
-  useEffect(() => {
-    setMainnetRPC(window.localStorage.getItem(MAINNET_RPC_URL) || '');
-    setXDaiRPC(window.localStorage.getItem(XDAI_RPC_URL) || '');
-    setNeverShowClaims(
-      window.localStorage.getItem(NEVER_SHOW_CLAIMS) === 'true',
-    );
-    setInfiniteUnlock(window.localStorage.getItem(INFINITE_UNLOCK) === 'true');
-    setNeedsSaving(false);
-  }, [trigger]);
-
-  const update = () => shouldTrigger(t => !t);
   const save = useCallback(() => {
-    if (needsSaving) {
-      window.localStorage.setItem(MAINNET_RPC_URL, mainnetRPC);
-      window.localStorage.setItem(XDAI_RPC_URL, xdaiRPC);
-      window.localStorage.setItem(NEVER_SHOW_CLAIMS, neverShowClaims);
-      window.localStorage.setItem(INFINITE_UNLOCK, infiniteUnlock);
-      setNeedsSaving(false);
-    }
-  }, [mainnetRPC, xdaiRPC, neverShowClaims, infiniteUnlock, needsSaving]);
-
-  useEffect(() => {
-    if (
-      window.localStorage.getItem(XDAI_RPC_URL) !== xdaiRPC ||
-      window.localStorage.getItem(MAINNET_RPC_URL) !== mainnetRPC ||
-      (window.localStorage.getItem(NEVER_SHOW_CLAIMS) === 'true') !==
-        neverShowClaims ||
-      (window.localStorage.getItem(INFINITE_UNLOCK) === 'true') !==
-        infiniteUnlock
-    ) {
-      setNeedsSaving(true);
-    }
-  }, [mainnetRPC, xdaiRPC, neverShowClaims, infiniteUnlock]);
+    setMainnetRPC(mRPC => mRPC);
+    setXDaiRPC(xRPC => xRPC);
+    setNeverShowClaims(nClaims => nClaims);
+    setInfiniteUnlock(iUnlock => iUnlock);
+  }, [setInfiniteUnlock, setMainnetRPC, setXDaiRPC, setNeverShowClaims]);
 
   return (
     <SettingsContext.Provider
@@ -73,9 +52,7 @@ export const SettingsProvider = ({ children }) => {
         setNeverShowClaims,
         disableBalanceFetchToken,
         setDisableBalanceFetchToken,
-        update,
         save,
-        needsSaving,
       }}
     >
       {children}

--- a/packages/react-app/src/hooks/useLocalState.js
+++ b/packages/react-app/src/hooks/useLocalState.js
@@ -20,10 +20,11 @@ const useLocalState = (
 
   const updateValue = useCallback(
     val => {
-      console.log(val, typeof val);
       const result = typeof val === 'function' ? val(value) : val;
-      localStorage.setItem(key, result);
-      setValue(result);
+      if (JSON.stringify(result) !== JSON.stringify(value)) {
+        localStorage.setItem(key, result);
+        setValue(result);
+      }
     },
     [key, value],
   );

--- a/packages/react-app/src/hooks/useLocalState.js
+++ b/packages/react-app/src/hooks/useLocalState.js
@@ -1,10 +1,26 @@
 import { useCallback, useEffect, useState } from 'react';
 
-const useLocalState = (initialValue, key = 'omnibridge-key') => {
-  const [value, setValue] = useState(localStorage.getItem(key) || initialValue);
+const useLocalState = (
+  initialValue,
+  key = 'omnibridge-key',
+  valueType = 'string',
+) => {
+  const storageValue = localStorage.getItem(key);
+  let castedValue = storageValue;
+
+  if (valueType === 'number') {
+    castedValue = parseInt(storageValue, 10);
+  } else if (valueType === 'boolean') {
+    castedValue = Boolean(storageValue);
+  } else if (valueType === 'object') {
+    castedValue = JSON.parse(storageValue);
+  }
+
+  const [value, setValue] = useState(castedValue || initialValue);
 
   const updateValue = useCallback(
     val => {
+      console.log(val, typeof val);
       const result = typeof val === 'function' ? val(value) : val;
       localStorage.setItem(key, result);
       setValue(result);

--- a/packages/react-app/src/hooks/useLocalState.js
+++ b/packages/react-app/src/hooks/useLocalState.js
@@ -1,0 +1,21 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const useLocalState = (initialValue, key) => {
+  const [value, setValue] = useState(initialValue);
+
+  const updateValue = useCallback(
+    val => {
+      localStorage.setItem(key, val);
+      setValue(val);
+    },
+    [key],
+  );
+
+  useEffect(() => {
+    updateValue(value);
+  }, [value, updateValue]);
+
+  return [value, updateValue];
+};
+
+export { useLocalState };

--- a/packages/react-app/src/hooks/useLocalState.js
+++ b/packages/react-app/src/hooks/useLocalState.js
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useState } from 'react';
 
-const useLocalState = (initialValue, key) => {
-  const [value, setValue] = useState(initialValue);
+const useLocalState = (initialValue, key = 'omnibridge-key') => {
+  const [value, setValue] = useState(localStorage.getItem(key) || initialValue);
 
   const updateValue = useCallback(
     val => {
-      localStorage.setItem(key, val);
-      setValue(val);
+      const result = typeof val === 'function' ? val(value) : val;
+      localStorage.setItem(key, result);
+      setValue(result);
     },
-    [key],
+    [key, value],
   );
 
   useEffect(() => {

--- a/packages/react-app/src/lib/constants.js
+++ b/packages/react-app/src/lib/constants.js
@@ -144,4 +144,5 @@ export const LOCAL_STORAGE_KEYS = {
   NEVER_SHOW_CLAIMS: 'never-show-claims',
   INFINITE_UNLOCK: 'infinite-unlock',
   CUSTOM_TOKENS: 'customTokens',
+  DISABLE_BALANCE_WHILE_TOKEN_FETCH: 'disable-balance-while-token-fetch',
 };


### PR DESCRIPTION
A toggle has been added over the settings page (Screenshot attached below) which is by default unchecked.
<img width="478" alt="Screenshot 2021-03-18 at 2 39 46 AM" src="https://user-images.githubusercontent.com/32637757/111538854-35f31f00-8793-11eb-9631-64ffef79feb3.png">

This toggle makes sure to get tokens without balance (Screenshot attached below)
<img width="483" alt="Screenshot 2021-03-18 at 2 40 27 AM" src="https://user-images.githubusercontent.com/32637757/111538938-4e633980-8793-11eb-9ae7-b2054037dd8e.png">

And with balance when toggled
<img width="477" alt="Screenshot 2021-03-18 at 2 40 52 AM" src="https://user-images.githubusercontent.com/32637757/111538983-5cb15580-8793-11eb-8d2b-b3ab9d399142.png">
<img width="481" alt="Screenshot 2021-03-18 at 2 41 06 AM" src="https://user-images.githubusercontent.com/32637757/111538999-65a22700-8793-11eb-83d2-9ecc94e00284.png">

Closes #151 