### PR TITLE
feat: api to pre setup token and chain

### DIFF
--- a/packages/react-app/src/components/bridge/FromToken.jsx
+++ b/packages/react-app/src/components/bridge/FromToken.jsx
@@ -21,7 +21,6 @@ import { defer } from 'rxjs';
 
 export const FromToken = () => {
   const { account, providerChainId: chainId } = useWeb3Context();
-  const { isCustomTokenAbsent } = useContext(BridgeContext);
   const {
     updateBalance,
     fromToken: token,
@@ -35,10 +34,6 @@ export const FromToken = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const smallScreen = useBreakpointValue({ base: true, lg: false });
   const [balanceLoading, setBalanceLoading] = useState(false);
-
-  useEffect(() => {
-    isCustomTokenAbsent && onOpen();
-  }, [isCustomTokenAbsent, onOpen]);
 
   useEffect(() => {
     let subscription;
@@ -84,11 +79,7 @@ export const FromToken = () => {
       minH={smallScreen ? '5rem' : 8}
       minW={smallScreen ? '15rem' : undefined}
     >
-      <SelectTokenModal
-        onClose={onClose}
-        isOpen={isOpen}
-        isCustomTokenAbsent={isCustomTokenAbsent}
-      />
+      <SelectTokenModal onClose={onClose} isOpen={isOpen} />
       {!smallScreen && (
         <svg width="100%" viewBox="0 0 381 94" fill="none">
           <path

--- a/packages/react-app/src/components/bridge/FromToken.jsx
+++ b/packages/react-app/src/components/bridge/FromToken.jsx
@@ -21,6 +21,7 @@ import { defer } from 'rxjs';
 
 export const FromToken = () => {
   const { account, providerChainId: chainId } = useWeb3Context();
+  const { isCustomTokenAbsent } = useContext(BridgeContext);
   const {
     updateBalance,
     fromToken: token,
@@ -34,6 +35,10 @@ export const FromToken = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const smallScreen = useBreakpointValue({ base: true, lg: false });
   const [balanceLoading, setBalanceLoading] = useState(false);
+
+  useEffect(() => {
+    isCustomTokenAbsent && onOpen();
+  }, [isCustomTokenAbsent, onOpen]);
 
   useEffect(() => {
     let subscription;
@@ -79,7 +84,11 @@ export const FromToken = () => {
       minH={smallScreen ? '5rem' : 8}
       minW={smallScreen ? '15rem' : undefined}
     >
-      <SelectTokenModal onClose={onClose} isOpen={isOpen} />
+      <SelectTokenModal
+        onClose={onClose}
+        isOpen={isOpen}
+        isCustomTokenAbsent={isCustomTokenAbsent}
+      />
       {!smallScreen && (
         <svg width="100%" viewBox="0 0 381 94" fill="none">
           <path

--- a/packages/react-app/src/components/common/ConnectWeb3.jsx
+++ b/packages/react-app/src/components/common/ConnectWeb3.jsx
@@ -26,7 +26,7 @@ export const ConnectWeb3 = () => {
     account,
     disconnect,
     ethersProvider,
-    isChainIdInjected,
+    customChainId,
   } = useWeb3Context();
   const toast = useToast();
 
@@ -79,12 +79,13 @@ export const ConnectWeb3 = () => {
   };
 
   const renderHelperBox = () => {
-    const { chainId, status } = isChainIdInjected;
-    if (status && [HOME_CHAIN_ID, FOREIGN_CHAIN_ID].includes(chainId)) {
+    if (
+      customChainId &&
+      [HOME_CHAIN_ID, FOREIGN_CHAIN_ID].includes(customChainId)
+    ) {
       return (
         <Text color="greyText" mb={4} textAlign="center">
-          Please switch to {renderConnectChain(isChainIdInjected.chainId)} for
-          swapping
+          Please switch to {renderConnectChain(customChainId)} for swapping
         </Text>
       );
     }
@@ -128,11 +129,7 @@ export const ConnectWeb3 = () => {
       ) : (
         <>
           <Text fontSize="xl" fontWeight="bold" mb={4}>
-            {account
-              ? `Switch to a ${
-                  isChainIdInjected.status ? 'chosen' : 'supported'
-                } network`
-              : 'Connect Wallet'}
+            {account ? `Switch your network` : 'Connect Wallet'}
           </Text>
 
           {!account ? (

--- a/packages/react-app/src/components/common/ConnectWeb3.jsx
+++ b/packages/react-app/src/components/common/ConnectWeb3.jsx
@@ -26,6 +26,7 @@ export const ConnectWeb3 = () => {
     account,
     disconnect,
     ethersProvider,
+    isChainIdInjected,
   } = useWeb3Context();
   const toast = useToast();
 
@@ -73,7 +74,26 @@ export const ConnectWeb3 = () => {
         </Badge>
       </Tooltip>
     ) : (
-      networkName
+      <span style={{ fontWeight: 'bold' }}>{networkName}</span>
+    );
+  };
+
+  const renderHelperBox = () => {
+    const { chainId, status } = isChainIdInjected;
+    if (status && [HOME_CHAIN_ID, FOREIGN_CHAIN_ID].includes(chainId)) {
+      return (
+        <Text color="greyText" mb={4} textAlign="center">
+          Please switch to {renderConnectChain(isChainIdInjected.chainId)} for
+          swapping
+        </Text>
+      );
+    }
+    return (
+      <Text color="greyText" mb={4} textAlign="center">
+        To access OmniBridge, please switch to
+        {renderConnectChain(HOME_CHAIN_ID)}or{' '}
+        {renderConnectChain(FOREIGN_CHAIN_ID)}
+      </Text>
     );
   };
 
@@ -116,11 +136,7 @@ export const ConnectWeb3 = () => {
               To get started, connect your wallet
             </Text>
           ) : (
-            <Text color="greyText" mb={4} textAlign="center">
-              To access OmniBridge, please switch to
-              {renderConnectChain(HOME_CHAIN_ID)}or{' '}
-              {renderConnectChain(FOREIGN_CHAIN_ID)}
-            </Text>
+            renderHelperBox()
           )}
         </>
       )}

--- a/packages/react-app/src/components/common/ConnectWeb3.jsx
+++ b/packages/react-app/src/components/common/ConnectWeb3.jsx
@@ -128,7 +128,11 @@ export const ConnectWeb3 = () => {
       ) : (
         <>
           <Text fontSize="xl" fontWeight="bold" mb={4}>
-            {account ? `Switch to a supported network` : 'Connect Wallet'}
+            {account
+              ? `Switch to a ${
+                  isChainIdInjected.status ? 'chosen' : 'supported'
+                } network`
+              : 'Connect Wallet'}
           </Text>
 
           {!account ? (

--- a/packages/react-app/src/components/common/Layout.jsx
+++ b/packages/react-app/src/components/common/Layout.jsx
@@ -10,15 +10,10 @@ import { FOREIGN_CHAIN_ID, HOME_CHAIN_ID } from 'lib/constants';
 import React from 'react';
 
 export const Layout = ({ children }) => {
-  const {
-    account,
-    loading,
-    providerChainId,
-    isChainIdInjected: { chainId, status },
-  } = useWeb3Context();
+  const { account, loading, providerChainId, customChainId } = useWeb3Context();
 
   let isCustomChainProvided = false;
-  if (status && providerChainId !== chainId) {
+  if (customChainId && providerChainId !== customChainId) {
     isCustomChainProvided = true;
   }
 

--- a/packages/react-app/src/components/common/Layout.jsx
+++ b/packages/react-app/src/components/common/Layout.jsx
@@ -10,10 +10,24 @@ import { FOREIGN_CHAIN_ID, HOME_CHAIN_ID } from 'lib/constants';
 import React from 'react';
 
 export const Layout = ({ children }) => {
-  const { account, providerChainId } = useWeb3Context();
+  const {
+    account,
+    loading,
+    providerChainId,
+    isChainIdInjected: { chainId, status },
+  } = useWeb3Context();
+
+  let isCustomChainProvided = false;
+  if (status && providerChainId !== chainId) {
+    isCustomChainProvided = true;
+  }
+
   const valid =
+    !loading &&
+    !isCustomChainProvided &&
     !!account &&
     [HOME_CHAIN_ID, FOREIGN_CHAIN_ID].indexOf(providerChainId) >= 0;
+
   return (
     <Flex
       p={0}

--- a/packages/react-app/src/components/modals/SelectTokenModal.jsx
+++ b/packages/react-app/src/components/modals/SelectTokenModal.jsx
@@ -1,34 +1,26 @@
 import { CustomTokenModal } from 'components/modals/CustomTokenModal';
 import { TokenSelectorModal } from 'components/modals/TokenSelectorModal';
-import { BridgeContext } from 'contexts/BridgeContext';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
-export const SelectTokenModal = ({ isOpen, onClose, isCustomTokenAbsent }) => {
-  const { setIsCustomTokenAbsent } = useContext(BridgeContext);
+export const SelectTokenModal = ({ isOpen, onClose }) => {
   const [custom, setCustom] = useState(false);
-
-  useEffect(() => {
-    isCustomTokenAbsent && setCustom(true);
-  }, [isCustomTokenAbsent]);
-
-  const handleClose = () => {
-    setIsCustomTokenAbsent(false);
-    onClose();
-  };
 
   return (
     <>
       {!custom && (
         <TokenSelectorModal
           isOpen={isOpen}
-          onClose={handleClose}
+          onClose={onClose}
           onCustom={() => setCustom(true)}
         />
       )}
       {custom && (
         <CustomTokenModal
           isOpen={isOpen}
-          onClose={handleClose}
+          onClose={() => {
+            setCustom(false);
+            onClose();
+          }}
           onBack={() => setCustom(false)}
         />
       )}

--- a/packages/react-app/src/components/modals/SelectTokenModal.jsx
+++ b/packages/react-app/src/components/modals/SelectTokenModal.jsx
@@ -1,22 +1,34 @@
 import { CustomTokenModal } from 'components/modals/CustomTokenModal';
 import { TokenSelectorModal } from 'components/modals/TokenSelectorModal';
-import React, { useState } from 'react';
+import { BridgeContext } from 'contexts/BridgeContext';
+import React, { useContext, useEffect, useState } from 'react';
 
-export const SelectTokenModal = ({ isOpen, onClose }) => {
+export const SelectTokenModal = ({ isOpen, onClose, isCustomTokenAbsent }) => {
+  const { setIsCustomTokenAbsent } = useContext(BridgeContext);
   const [custom, setCustom] = useState(false);
+
+  useEffect(() => {
+    isCustomTokenAbsent && setCustom(true);
+  }, [isCustomTokenAbsent]);
+
+  const handleClose = () => {
+    setIsCustomTokenAbsent(false);
+    onClose();
+  };
+
   return (
     <>
       {!custom && (
         <TokenSelectorModal
           isOpen={isOpen}
-          onClose={onClose}
+          onClose={handleClose}
           onCustom={() => setCustom(true)}
         />
       )}
       {custom && (
         <CustomTokenModal
           isOpen={isOpen}
-          onClose={onClose}
+          onClose={handleClose}
           onBack={() => setCustom(false)}
         />
       )}

--- a/packages/react-app/src/components/modals/TokenSelectorModal.jsx
+++ b/packages/react-app/src/components/modals/TokenSelectorModal.jsx
@@ -22,6 +22,7 @@ import { BridgeContext } from 'contexts/BridgeContext';
 import { useSettings } from 'contexts/SettingsContext';
 import { useWeb3Context } from 'contexts/Web3Context';
 import { PlusIcon } from 'icons/PlusIcon';
+import { LOCAL_STORAGE_KEYS } from 'lib/constants';
 import { formatValue, logError, uniqueTokens } from 'lib/helpers';
 import { fetchTokenBalanceWithProvider } from 'lib/token';
 import { fetchTokenList } from 'lib/tokenList';
@@ -32,6 +33,8 @@ import React, {
   useRef,
   useState,
 } from 'react';
+
+const { CUSTOM_TOKENS } = LOCAL_STORAGE_KEYS;
 
 export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
   // Ref
@@ -73,6 +76,7 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
       setLoading(true);
       try {
         const baseTokenList = await fetchTokenList(chainId);
+        console.log(baseTokenList);
         const customTokenList = uniqueTokens(
           baseTokenList.concat(
             customTokens.filter(token => token.chainId === chainId),
@@ -98,7 +102,7 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
 
   useEffect(() => {
     if (!isOpen) return;
-    let localTokenList = window.localStorage.getItem('customTokens');
+    let localTokenList = window.localStorage.getItem(CUSTOM_TOKENS);
     localTokenList =
       !localTokenList || !localTokenList.length
         ? []

--- a/packages/react-app/src/components/modals/TokenSelectorModal.jsx
+++ b/packages/react-app/src/components/modals/TokenSelectorModal.jsx
@@ -76,7 +76,6 @@ export const TokenSelectorModal = ({ isOpen, onClose, onCustom }) => {
       setLoading(true);
       try {
         const baseTokenList = await fetchTokenList(chainId);
-        console.log(baseTokenList);
         const customTokenList = uniqueTokens(
           baseTokenList.concat(
             customTokens.filter(token => token.chainId === chainId),

--- a/packages/react-app/src/contexts/BridgeContext.jsx
+++ b/packages/react-app/src/contexts/BridgeContext.jsx
@@ -29,6 +29,7 @@ export const BridgeProvider = ({ children }) => {
   const { ethersProvider, account, providerChainId } = useWeb3Context();
 
   const [receiver, setReceiver] = useState('');
+  const [amountInput, setAmountInput] = useState('');
   const [{ fromToken, toToken }, setTokens] = useState({});
   const [{ fromAmount, toAmount }, setAmounts] = useState({
     fromAmount: BigNumber.from(0),
@@ -36,17 +37,17 @@ export const BridgeProvider = ({ children }) => {
   });
   const [toAmountLoading, setToAmountLoading] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [txHash, setTxHash] = useState();
-  const [amountInput, setAmountInput] = useState('');
+  const [updateBalance, setUpdateBalance] = useState(false);
   const [fromBalance, setFromBalance] = useState(BigNumber.from(0));
   const [toBalance, setToBalance] = useState(BigNumber.from(0));
+  const [txHash, setTxHash] = useState();
   const [tokenLimits, setTokenLimits] = useState();
 
+  const toast = useToast();
   const totalConfirms = useTotalConfirms();
   const isRewardAddress = useRewardAddress();
   const currentDay = useCurrentDay();
   const { homeToForeignFeeType, foreignToHomeFeeType } = useFeeType();
-  const [updateBalance, setUpdateBalance] = useState(false);
   const {
     allowed,
     updateAllowance,
@@ -81,8 +82,6 @@ export const BridgeProvider = ({ children }) => {
       foreignToHomeFeeType,
     ],
   );
-
-  const toast = useToast();
 
   const setToken = useCallback(
     async tokenWithoutMode => {

--- a/packages/react-app/src/contexts/BridgeContext.jsx
+++ b/packages/react-app/src/contexts/BridgeContext.jsx
@@ -158,7 +158,7 @@ export const BridgeProvider = ({ children }) => {
     } else if (!fromToken || !toToken) {
       const isCustomTokenSet = await setToken({
         chainId: providerChainId,
-        customTokenAddress,
+        address: customTokenAddress,
       });
       !isCustomTokenSet && (await setDefaultToken(providerChainId));
     }

--- a/packages/react-app/src/contexts/BridgeContext.jsx
+++ b/packages/react-app/src/contexts/BridgeContext.jsx
@@ -182,8 +182,7 @@ export const BridgeProvider = ({ children }) => {
 
   useEffect(() => {
     queryTrigger !== null && queryTrigger === false && checkForCustomToken();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [queryTrigger]);
+  }, [queryTrigger, checkForCustomToken]);
 
   const updateTokenLimits = useCallback(async () => {
     if (

--- a/packages/react-app/src/contexts/Web3Context.jsx
+++ b/packages/react-app/src/contexts/Web3Context.jsx
@@ -56,10 +56,7 @@ export const Web3Provider = ({ children }) => {
   const { providerChainId, ethersProvider } = web3State;
   const [account, setAccount] = useState();
   const [loading, setLoading] = useState(true);
-  const [isChainIdInjected, setIsChainIdInjected] = useState({
-    status: false,
-    chainId: null,
-  });
+  const [customChainId, setCustomChainId] = useState(null);
 
   const setWeb3Provider = useCallback(async (prov, updateAccount = false) => {
     try {
@@ -101,10 +98,7 @@ export const Web3Provider = ({ children }) => {
           parseInt(queryParams?.from, 10),
         )
       ) {
-        setIsChainIdInjected({
-          status: true,
-          chainId: parseInt(queryParams.from, 10),
-        });
+        setCustomChainId(parseInt(queryParams.from, 10));
       }
 
       const modalProvider = await web3Modal.connect();
@@ -152,7 +146,7 @@ export const Web3Provider = ({ children }) => {
         disconnect,
         providerChainId,
         account,
-        isChainIdInjected,
+        customChainId,
       }}
     >
       {children}

--- a/packages/react-app/src/contexts/Web3Context.jsx
+++ b/packages/react-app/src/contexts/Web3Context.jsx
@@ -1,6 +1,11 @@
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import { ethers } from 'ethers';
-import { getNetworkName, getRPCUrl, logError } from 'lib/helpers';
+import {
+  fetchQueryParams,
+  getNetworkName,
+  getRPCUrl,
+  logError,
+} from 'lib/helpers';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import Web3 from 'web3';
 import Web3Modal from 'web3modal';
@@ -50,6 +55,10 @@ export const Web3Provider = ({ children }) => {
   const { providerChainId, ethersProvider } = web3State;
   const [account, setAccount] = useState();
   const [loading, setLoading] = useState(true);
+  const [isChainIdInjected, setIsChainIdInjected] = useState({
+    status: false,
+    chainId: null,
+  });
 
   const setWeb3Provider = useCallback(async (prov, updateAccount = false) => {
     try {
@@ -83,6 +92,12 @@ export const Web3Provider = ({ children }) => {
   const connectWeb3 = useCallback(async () => {
     try {
       setLoading(true);
+      const queryParams = fetchQueryParams();
+      if (queryParams?.from)
+        setIsChainIdInjected({
+          status: true,
+          chainId: parseInt(queryParams.from, 10),
+        });
       const modalProvider = await web3Modal.connect();
 
       await setWeb3Provider(modalProvider, true);
@@ -128,6 +143,7 @@ export const Web3Provider = ({ children }) => {
         disconnect,
         providerChainId,
         account,
+        isChainIdInjected,
       }}
     >
       {children}

--- a/packages/react-app/src/contexts/Web3Context.jsx
+++ b/packages/react-app/src/contexts/Web3Context.jsx
@@ -61,11 +61,6 @@ export const Web3Provider = ({ children }) => {
     chainId: null,
   });
 
-  const [isTokenInjected, setIsTokenInjected] = useState({
-    status: false,
-    token: null,
-  });
-
   const setWeb3Provider = useCallback(async (prov, updateAccount = false) => {
     try {
       if (prov) {
@@ -109,13 +104,6 @@ export const Web3Provider = ({ children }) => {
         setIsChainIdInjected({
           status: true,
           chainId: parseInt(queryParams.from, 10),
-        });
-      }
-
-      if (queryParams?.token) {
-        setIsTokenInjected({
-          status: true,
-          token: queryParams.token.toLowerCase(),
         });
       }
 
@@ -165,7 +153,6 @@ export const Web3Provider = ({ children }) => {
         providerChainId,
         account,
         isChainIdInjected,
-        isTokenInjected,
       }}
     >
       {children}

--- a/packages/react-app/src/contexts/Web3Context.jsx
+++ b/packages/react-app/src/contexts/Web3Context.jsx
@@ -1,5 +1,6 @@
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import { ethers } from 'ethers';
+import { FOREIGN_CHAIN_ID, HOME_CHAIN_ID } from 'lib/constants';
 import {
   fetchQueryParams,
   getNetworkName,
@@ -99,7 +100,12 @@ export const Web3Provider = ({ children }) => {
       setLoading(true);
       const queryParams = fetchQueryParams();
 
-      if (queryParams?.from) {
+      if (
+        queryParams?.from &&
+        [HOME_CHAIN_ID, FOREIGN_CHAIN_ID].includes(
+          parseInt(queryParams?.from, 10),
+        )
+      ) {
         setIsChainIdInjected({
           status: true,
           chainId: parseInt(queryParams.from, 10),

--- a/packages/react-app/src/contexts/Web3Context.jsx
+++ b/packages/react-app/src/contexts/Web3Context.jsx
@@ -60,6 +60,11 @@ export const Web3Provider = ({ children }) => {
     chainId: null,
   });
 
+  const [isTokenInjected, setIsTokenInjected] = useState({
+    status: false,
+    token: null,
+  });
+
   const setWeb3Provider = useCallback(async (prov, updateAccount = false) => {
     try {
       if (prov) {
@@ -93,11 +98,21 @@ export const Web3Provider = ({ children }) => {
     try {
       setLoading(true);
       const queryParams = fetchQueryParams();
-      if (queryParams?.from)
+
+      if (queryParams?.from) {
         setIsChainIdInjected({
           status: true,
           chainId: parseInt(queryParams.from, 10),
         });
+      }
+
+      if (queryParams?.token) {
+        setIsTokenInjected({
+          status: true,
+          token: queryParams.token.toLowerCase(),
+        });
+      }
+
       const modalProvider = await web3Modal.connect();
 
       await setWeb3Provider(modalProvider, true);
@@ -144,6 +159,7 @@ export const Web3Provider = ({ children }) => {
         providerChainId,
         account,
         isChainIdInjected,
+        isTokenInjected,
       }}
     >
       {children}

--- a/packages/react-app/src/lib/helpers.js
+++ b/packages/react-app/src/lib/helpers.js
@@ -76,9 +76,7 @@ export const uniqueTokens = list => {
 export const formatValue = (num, dec) => {
   const str = utils.formatUnits(num, dec);
   if (str.length > 50) {
-    const expStr = Number(str)
-      .toExponential()
-      .replace(/e\+?/, ' x 10^');
+    const expStr = Number(str).toExponential().replace(/e\+?/, ' x 10^');
     const split = expStr.split(' x 10^');
     const first = Number(split[0]).toLocaleString('en', {
       maximumFractionDigits: 4,
@@ -117,6 +115,19 @@ export const uriToHttp = uri => {
     default:
       return [];
   }
+};
+
+export const fetchQueryParams = () => {
+  const { search } = new URL(window.location);
+  if (!search.trim().length) return null;
+  return search
+    .replace('?', '')
+    .split(/&/g)
+    .reduce((acc, keyValuePair) => {
+      const [key, value] = keyValuePair.split('=');
+      acc[key] = value;
+      return acc;
+    }, {});
 };
 
 export const getAccountString = account => {


### PR DESCRIPTION
I tried giving a shot to hit it right, but there could be cases additionally. However, I will list out the cases I have considered

## 0. Default option (no chain nor token):
https://user-images.githubusercontent.com/32637757/111861207-7c52a480-8972-11eb-9b8a-ec4759bc1c59.mov
It will work as expected (get from metamask and yells if not using FOREIGN OR HOME CHAIN). 

## 1. When chainId is given but of foreign:
https://user-images.githubusercontent.com/32637757/111861148-2c73dd80-8972-11eb-942a-9fd99eeb9576.mov
In this case, it will pinpoint the user which chain to be connected with, instead of having the "this or that" statement

## 2. When chainId is given as home and user also is on the same provider
https://user-images.githubusercontent.com/32637757/111861248-c9367b00-8972-11eb-8aa7-32d9aca59198.mov
Here, it is similar as case 0.

## 3. When chainId is invalid (neither foreign nor home)
https://user-images.githubusercontent.com/32637757/111861270-ec612a80-8972-11eb-9ff5-21fd26635f7b.mov
In this case, it won't take the chainId user has passed into account. 

## 4. When the token's symbol matches the token list of the given chain
https://user-images.githubusercontent.com/32637757/111861290-0995f900-8973-11eb-90a8-304b4d44e01b.mov
What happens here is it checks with the token list of that chain and gets the to and from token of the same. 

## 5. When the token's symbol does not match.
https://user-images.githubusercontent.com/32637757/111861305-1e728c80-8973-11eb-923f-03459209a36b.mov
This was a little tricky. If the user types something which doesn't match with the token list. He/She is brought up a modal to add a new token form (This can be changed if felt a Lil cut-off, but I was feeling this was intuitive instead). Meanwhile, the default token (STAKE) is fetched behind as usual, but once the user finishes filling off the token, this token would replace STAKE. 

(Again, I was not sure about this step. Either we could have fetched all the token fields as query params, or manual entry would have been decided, but hey I am all ears haha). 

Apologies for the bombardment of screen shares @dan13ram .. 