### PR TITLE
generalised unlock error handling

### DIFF
--- a/packages/react-app/src/components/bridge/UnlockButton.jsx
+++ b/packages/react-app/src/components/bridge/UnlockButton.jsx
@@ -41,7 +41,11 @@ export const UnlockButton = () => {
     if (!unlockLoading && !allowed && valid()) {
       approve().catch(error => {
         if (error && error.message) {
-          if (error.data === 'Bad instruction fe') {
+          if (
+            error.data &&
+            (error.data.includes('Bad instruction fe') ||
+              error.data.includes('Reverted'))
+          ) {
             showError(
               <Text>
                 There is problem with the token unlock. Try to revoke previous
@@ -53,7 +57,7 @@ export const UnlockButton = () => {
                 >
                   https://revoke.cash/
                 </Link>{' '}
-                and unlock the tokens again.
+                and try again.
               </Text>,
             );
           } else {


### PR DESCRIPTION
@akolotov As per your request I've updated the error handling, to handle both `revert` and `assert`.
Please let me know if this looks good :)