### PR TITLE
feat: Bridge native to ERC677 (foreign to home)

### DIFF
--- a/packages/react-app/src/components/modals/ConfirmTransferModal.jsx
+++ b/packages/react-app/src/components/modals/ConfirmTransferModal.jsx
@@ -20,6 +20,7 @@ import { NeedsTransactions } from 'components/modals/NeedsTransactionsModal';
 import { DaiWarning, isERC20DaiAddress } from 'components/warnings/DaiWarning';
 import { BridgeContext } from 'contexts/BridgeContext';
 import { useBridgeDirection } from 'hooks/useBridgeDirection';
+import { NATIVE_CURRENCY_SYBMOLS } from 'lib/constants';
 import { formatValue, getAccountString, getNetworkLabel } from 'lib/helpers';
 import React, { useContext, useEffect, useState } from 'react';
 
@@ -48,7 +49,9 @@ export const ConfirmTransferModal = ({ isOpen, onClose }) => {
   const fromAmt = formatValue(fromAmount, fromToken.decimals);
   const fromUnit = fromToken.symbol;
   const toAmt = formatValue(toAmount, toToken.decimals);
-  const toUnit = toToken.symbol;
+  const toUnit = NATIVE_CURRENCY_SYBMOLS.includes(toToken.symbol)
+    ? toToken.destinationTokenSymbol
+    : toToken.symbol;
   const isERC20Dai =
     !!fromToken &&
     fromToken.chainId === foreignChainId &&

--- a/packages/react-app/src/contexts/BridgeContext.jsx
+++ b/packages/react-app/src/contexts/BridgeContext.jsx
@@ -12,8 +12,9 @@ import {
   fetchTokenLimits,
   fetchToToken,
   relayTokens,
+  wrapAndRelayTokens,
 } from 'lib/bridge';
-import { ADDRESS_ZERO } from 'lib/constants';
+import { ADDRESS_ZERO, NATIVE_CURRENCY_SYBMOLS } from 'lib/constants';
 import { getDefaultToken, logError, parseValue } from 'lib/helpers';
 import { fetchTokenDetails } from 'lib/token';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -127,12 +128,19 @@ export const BridgeProvider = ({ children }) => {
   const transfer = useCallback(async () => {
     setLoading(true);
     try {
-      const tx = await relayTokens(
-        ethersProvider,
-        fromToken,
-        receiver || account,
-        fromAmount,
-      );
+      const tx = NATIVE_CURRENCY_SYBMOLS.includes(fromToken.symbol)
+        ? await wrapAndRelayTokens(
+            ethersProvider,
+            fromToken,
+            receiver || account,
+            fromAmount,
+          )
+        : await relayTokens(
+            ethersProvider,
+            fromToken,
+            receiver || account,
+            fromAmount,
+          );
       setTxHash(tx.hash);
     } catch (transferError) {
       setLoading(false);

--- a/packages/react-app/src/hooks/useApproval.js
+++ b/packages/react-app/src/hooks/useApproval.js
@@ -22,7 +22,8 @@ export const useApproval = (fromToken, fromAmount) => {
 
   useEffect(() => {
     setAllowed(
-      (fromToken && fromToken.mode === 'erc677') || allowance.gte(fromAmount),
+      (fromToken && ['NATIVE', 'erc677'].includes(fromToken.mode)) ||
+        allowance.gte(fromAmount),
     );
   }, [fromAmount, allowance, fromToken]);
 

--- a/packages/react-app/src/lib/bridge.js
+++ b/packages/react-app/src/lib/bridge.js
@@ -81,7 +81,9 @@ const fetchToTokenDetails = async (bridgeDirection, fromToken, toChainId) => {
   );
 
   if (NATIVE_CURRENCY_SYBMOLS.includes(fromSybmol)) {
-    const toAddress = nativeCurrencies[fromChainId].destinationTokenAddress;
+    const { destinationTokenAddress: toAddress } = nativeCurrencies[
+      fromChainId
+    ];
     const toName = await getToName(
       { name: `W${fromSybmol}` },
       toChainId,
@@ -346,4 +348,17 @@ export const relayTokens = async (ethersProvider, token, receiver, amount) => {
       return mediatorContract.relayTokens(token.address, receiver, amount);
     }
   }
+};
+
+export const wrapAndRelayTokens = async (
+  ethersProvider,
+  token,
+  receiver,
+  amount,
+) => {
+  const signer = ethersProvider.getSigner();
+  const { helperContractAddress } = token;
+  const abi = ['function wrapAndRelayTokens(address _receiver) public payable'];
+  const helperContract = new Contract(helperContractAddress, abi, signer);
+  return helperContract.wrapAndRelayTokens(receiver, { value: amount });
 };

--- a/packages/react-app/src/lib/constants.js
+++ b/packages/react-app/src/lib/constants.js
@@ -33,7 +33,7 @@ export const nativeCurrencies = {
     address: ADDRESS_ZERO,
     name: 'Ether',
     symbol: 'ETH',
-    destinationTokenAddress: '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1',
+    destinationTokenAddress: '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1'.toLowerCase(),
     destinationTokenSymbol: 'WETH',
   },
   42: {
@@ -43,7 +43,7 @@ export const nativeCurrencies = {
     address: ADDRESS_ZERO,
     name: 'Kovan Ether',
     symbol: 'KETH',
-    destinationTokenAddress: '0x3D14493DF2B479E6BABE82Fc2373F91622bac025',
+    destinationTokenAddress: '0x3D14493DF2B479E6BABE82Fc2373F91622bac025'.toLowerCase(),
     destinationTokenSymbol: 'WKETH',
   },
   56: {
@@ -53,9 +53,15 @@ export const nativeCurrencies = {
     name: 'Binance Coin',
     address: ADDRESS_ZERO,
     symbol: 'BNB',
-    destinationTokenAddress: '0xCa8d20f3e0144a72C6B5d576e9Bd3Fd8557E2B04',
+    destinationTokenAddress: '0xCa8d20f3e0144a72C6B5d576e9Bd3Fd8557E2B04'.toLowerCase(),
     destinationTokenSymbol: 'WBNB',
   },
+};
+
+export const nativeCurrencyMediators = {
+  [NATIVE_CURRENCY_SYBMOLS[0]]: '',
+  [NATIVE_CURRENCY_SYBMOLS[1]]: '0x227a6f13aa0dba8912d740c0f88fb1304b2597e1'.toLowerCase(),
+  [NATIVE_CURRENCY_SYBMOLS[2]]: '0xefc33f8b2c4d51005585962be7ea20518ea9fd0d'.toLowerCase(),
 };
 
 export const networkNames = {

--- a/packages/react-app/src/lib/constants.js
+++ b/packages/react-app/src/lib/constants.js
@@ -5,6 +5,8 @@ import { ETH_XDAI_BRIDGE } from './networks';
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
 export const ETHER_CURRENCY_LOGO =
   'https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880';
+export const BNB_CURRENCY_LOGO =
+  'https://assets.coingecko.com/coins/images/825/small/binance-coin-logo.png?1547034615';
 
 export const LARGEST_UINT256 = BigNumber.from(
   '115792089237316195423570985008687907853269984665640564039457584007913129639935',
@@ -17,6 +19,7 @@ export const DEFAULT_BRIDGE_DIRECTION =
   process.env.REACT_APP_DEFAULT_BRIDGE_DIRECTION || ETH_XDAI_BRIDGE;
 
 export const NATIVE_CURRENCY_SYBMOLS = ['ETH', 'KETH', 'BNB'];
+export const NATIVE_CURRENCY_CHAIN_IDS = [1, 42, 56];
 
 export const NON_ETH_CHAIN_IDS = [56, 77, 100];
 
@@ -24,20 +27,35 @@ export const XDAI_CHAIN_IDS = [77, 100];
 
 export const nativeCurrencies = {
   1: {
+    chainId: 1,
     decimals: 18,
     logoURI: ETHER_CURRENCY_LOGO,
     address: ADDRESS_ZERO,
     name: 'Ether',
     symbol: 'ETH',
+    destinationTokenAddress: '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1',
+    destinationTokenSymbol: 'WETH',
   },
   42: {
+    chainId: 42,
     decimals: 18,
     logoURI: ETHER_CURRENCY_LOGO,
     address: ADDRESS_ZERO,
     name: 'Kovan Ether',
     symbol: 'KETH',
+    destinationTokenAddress: '0x3D14493DF2B479E6BABE82Fc2373F91622bac025',
+    destinationTokenSymbol: 'WKETH',
   },
-  56: {},
+  56: {
+    chainId: 56,
+    decimals: 18,
+    logoURI: BNB_CURRENCY_LOGO,
+    name: 'Binance Coin',
+    address: ADDRESS_ZERO,
+    symbol: 'BNB',
+    destinationTokenAddress: '0xCa8d20f3e0144a72C6B5d576e9Bd3Fd8557E2B04',
+    destinationTokenSymbol: 'WBNB',
+  },
 };
 
 export const networkNames = {

--- a/packages/react-app/src/lib/constants.js
+++ b/packages/react-app/src/lib/constants.js
@@ -3,6 +3,8 @@ import { BigNumber } from 'ethers';
 import { ETH_XDAI_BRIDGE } from './networks';
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
+export const ETHER_CURRENCY_LOGO =
+  'https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880';
 
 export const LARGEST_UINT256 = BigNumber.from(
   '115792089237316195423570985008687907853269984665640564039457584007913129639935',
@@ -14,9 +16,29 @@ export const POLLING_INTERVAL =
 export const DEFAULT_BRIDGE_DIRECTION =
   process.env.REACT_APP_DEFAULT_BRIDGE_DIRECTION || ETH_XDAI_BRIDGE;
 
+export const NATIVE_CURRENCY_SYBMOLS = ['ETH', 'KETH', 'BNB'];
+
 export const NON_ETH_CHAIN_IDS = [56, 77, 100];
 
 export const XDAI_CHAIN_IDS = [77, 100];
+
+export const nativeCurrencies = {
+  1: {
+    decimals: 18,
+    logoURI: ETHER_CURRENCY_LOGO,
+    address: ADDRESS_ZERO,
+    name: 'Ether',
+    symbol: 'ETH',
+  },
+  42: {
+    decimals: 18,
+    logoURI: ETHER_CURRENCY_LOGO,
+    address: ADDRESS_ZERO,
+    name: 'Kovan Ether',
+    symbol: 'KETH',
+  },
+  56: {},
+};
 
 export const networkNames = {
   1: 'ETH Mainnet',

--- a/packages/react-app/src/lib/helpers.js
+++ b/packages/react-app/src/lib/helpers.js
@@ -4,6 +4,7 @@ import {
   defaultTokens,
   defaultTokensUrl,
   LOCAL_STORAGE_KEYS,
+  nativeCurrencies,
   networkCurrencies,
   networkLabels,
   networkNames,
@@ -23,6 +24,8 @@ export const getDefaultToken = chainId =>
 export const getWalletProviderName = provider =>
   provider?.connection?.url || null;
 
+export const getNativeCurrency = chainId => nativeCurrencies[chainId || 1];
+
 export const getNetworkName = chainId =>
   networkNames[chainId] || 'Unknown Network';
 
@@ -39,6 +42,12 @@ export const getExplorerUrl = chainId =>
 
 export const getTokenListUrl = chainId =>
   defaultTokensUrl[chainId] || defaultTokensUrl[1];
+
+export const removeElement = (array, index) => {
+  const cloneArr = [...array];
+  cloneArr.splice(index, 1);
+  return cloneArr;
+};
 
 export const uniqueTokens = list => {
   const seen = {};

--- a/packages/react-app/src/lib/helpers.js
+++ b/packages/react-app/src/lib/helpers.js
@@ -5,6 +5,7 @@ import {
   defaultTokensUrl,
   LOCAL_STORAGE_KEYS,
   nativeCurrencies,
+  nativeCurrencyMediators,
   networkCurrencies,
   networkLabels,
   networkNames,
@@ -168,6 +169,9 @@ export const getRPCKeys = bridgeDirection => {
       };
   }
 };
+
+export const getHelperContract = currencySymbol =>
+  nativeCurrencyMediators[currencySymbol || 'ETH'];
 
 export const getMediatorAddressWithoutOverride = (bridgeDirection, chainId) => {
   if (!bridgeDirection || !chainId) return null;

--- a/packages/react-app/src/lib/token.js
+++ b/packages/react-app/src/lib/token.js
@@ -2,6 +2,7 @@ import { BigNumber, Contract, utils } from 'ethers';
 
 import { ADDRESS_ZERO, NATIVE_CURRENCY_SYBMOLS } from './constants';
 import {
+  getHelperContract,
   getMediatorAddress,
   getMediatorAddressWithoutOverride,
   logError,
@@ -123,6 +124,7 @@ export const fetchTokenDetails = async (bridgeDirection, token) => {
       decimals: Number(token.decimals),
       mode: 'NATIVE',
       mediator: mediatorAddress,
+      helperContractAddress: getHelperContract(token.symbol),
     };
   }
 

--- a/packages/react-app/src/lib/token.js
+++ b/packages/react-app/src/lib/token.js
@@ -118,10 +118,10 @@ export const fetchTokenDetails = async (bridgeDirection, token) => {
   const mediatorAddress = getMediatorAddress(bridgeDirection, token);
 
   if (NATIVE_CURRENCY_SYBMOLS.includes(token.symbol)) {
-    console.log('NATIVE CURRENCY SELECTED');
     return {
       ...token,
       decimals: Number(token.decimals),
+      mode: 'NATIVE',
       mediator: mediatorAddress,
     };
   }
@@ -158,9 +158,12 @@ export const fetchTokenBalance = async (token, account) => {
 
 export const fetchTokenBalanceWithProvider = async (
   ethersProvider,
-  { address },
+  { address, symbol },
   account,
 ) => {
+  if (NATIVE_CURRENCY_SYBMOLS.includes(symbol)) {
+    return ethersProvider.getBalance(account);
+  }
   if (!account || !address || address === ADDRESS_ZERO || !ethersProvider) {
     return BigNumber.from(0);
   }

--- a/packages/react-app/src/lib/token.js
+++ b/packages/react-app/src/lib/token.js
@@ -1,6 +1,6 @@
 import { BigNumber, Contract, utils } from 'ethers';
 
-import { ADDRESS_ZERO } from './constants';
+import { ADDRESS_ZERO, NATIVE_CURRENCY_SYBMOLS } from './constants';
 import {
   getMediatorAddress,
   getMediatorAddressWithoutOverride,
@@ -115,12 +115,21 @@ const fetchTokenDetailsFromContract = async token => {
 };
 
 export const fetchTokenDetails = async (bridgeDirection, token) => {
+  const mediatorAddress = getMediatorAddress(bridgeDirection, token);
+
+  if (NATIVE_CURRENCY_SYBMOLS.includes(token.symbol)) {
+    console.log('NATIVE CURRENCY SELECTED');
+    return {
+      ...token,
+      decimals: Number(token.decimals),
+      mediator: mediatorAddress,
+    };
+  }
+
   const [{ name, symbol, decimals }, mode] = await Promise.all([
     fetchTokenDetailsFromContract(token),
     fetchMode(bridgeDirection, token),
   ]);
-
-  const mediatorAddress = getMediatorAddress(bridgeDirection, token);
 
   return {
     ...token,


### PR DESCRIPTION
I have basically planned to cover up this issue in 2 parts. Foreign to home (this one), and view versa. 

The plan was to keep the native currency option at the top for easy access, followed by the tokens. 
<img width="476" alt="Screenshot 2021-04-11 at 7 51 20 PM" src="https://user-images.githubusercontent.com/32637757/114307884-4cc13300-9aff-11eb-9ca3-d4185af96b9a.png">

Same for Binance Smart Chain as well. 
<img width="477" alt="Screenshot 2021-04-11 at 7 54 09 PM" src="https://user-images.githubusercontent.com/32637757/114307953-afb2ca00-9aff-11eb-826b-252da6f2a6d5.png">

And Mainnet
<img width="477" alt="Screenshot 2021-04-11 at 7 55 00 PM" src="https://user-images.githubusercontent.com/32637757/114307977-cf49f280-9aff-11eb-8f2a-4625e8fa5d08.png">

I have attached the transaction as well as some screenshots beneath for the demo transfer which was done from the native currency of KOVAN (KETH) to SOKOL (WKETH), 

Transaction Hash - https://kovan.etherscan.io/tx/0xafe6c3dc0e89effaf6eff1e1aba5a94c5b238ec72c3b0f3d0c6d8abc76997c6e

Execution completion -
![](https://cdn.discordapp.com/attachments/819639802231259136/830797555171590144/Screenshot_2021-04-11_at_7.02.43_PM.png)

AMB Confirmation -
<img width="1275" alt="Screenshot 2021-04-11 at 7 53 11 PM" src="https://user-images.githubusercontent.com/32637757/114307931-8e51de00-9aff-11eb-9d4a-9a4ba5fef025.png">