### PR TITLE
Graph and RPC health alerts fix

### DIFF
--- a/packages/react-app/src/components/bridge/BridgeTokens.jsx
+++ b/packages/react-app/src/components/bridge/BridgeTokens.jsx
@@ -1,6 +1,7 @@
 import { Flex, Grid, Text, useBreakpointValue } from '@chakra-ui/react';
 import { AdvancedMenu } from 'components/bridge/AdvancedMenu';
 import { FromToken } from 'components/bridge/FromToken';
+import { RPCHealthAlert } from 'components/bridge/RPCHealthAlert';
 import { SystemFeedback } from 'components/bridge/SystemFeedback';
 import { ToToken } from 'components/bridge/ToToken';
 import { TransferButton } from 'components/bridge/TransferButton';
@@ -42,88 +43,95 @@ export const BridgeTokens = () => {
   const txNeedsClaiming = !!txHash && !loading && chainId === foreignChainId;
   return (
     <Flex
-      w={{ base: undefined, lg: 'calc(100% - 4rem)' }}
-      maxW="75rem"
-      background="white"
-      boxShadow="0px 1rem 2rem rgba(204, 218, 238, 0.8)"
-      borderRadius="1rem"
-      direction="column"
       align="center"
-      p={{ base: 4, md: 8 }}
-      mx={{ base: 4, sm: 8 }}
+      justify="center"
+      direction="column"
+      w={{ base: undefined, lg: 'calc(100% - 4rem)' }}
       my="auto"
+      mx={{ base: 4, sm: 8 }}
     >
-      <BridgeLoadingModal />
-      {txNeedsClaiming ? <ClaimTransferModal /> : null}
-      {txNeedsClaiming || neverShowClaims || needsSaving ? null : (
-        <ClaimTokensModal />
-      )}
-      {!smallScreen && (
-        <Flex w="100%" justify="space-between">
-          <Flex align="flex-start" direction="column">
-            <Text color="greyText" fontSize="sm">
-              From
-            </Text>
-            <Text fontWeight="bold" fontSize="lg">
-              {getNetworkName(chainId)}
-            </Text>
-          </Flex>
-          {isERC20Dai && <DaiWarning />}
-          {showReverseBridgeWarning && <ReverseWarning />}
-          <Flex align="flex-end" direction="column">
-            <Text color="greyText" fontSize="sm">
-              To
-            </Text>
-            <Text fontWeight="bold" fontSize="lg" textAlign="right">
-              {getNetworkName(bridgeChainId)}
-            </Text>
-          </Flex>
-        </Flex>
-      )}
-      <Grid
-        templateColumns={{ base: 'initial', lg: '2fr 1fr 2fr' }}
-        width="100%"
-        my={4}
+      <RPCHealthAlert />
+      <Flex
+        maxW="75rem"
+        background="white"
+        boxShadow="0px 1rem 2rem rgba(204, 218, 238, 0.8)"
+        borderRadius="1rem"
+        direction="column"
+        align="center"
+        p={{ base: 4, md: 8 }}
       >
-        {smallScreen && isERC20Dai && <DaiWarning />}
-        {smallScreen && showReverseBridgeWarning && (
-          <ReverseWarning isSmallScreen />
+        <BridgeLoadingModal />
+        {txNeedsClaiming ? <ClaimTransferModal /> : null}
+        {txNeedsClaiming || neverShowClaims || needsSaving ? null : (
+          <ClaimTokensModal />
         )}
-        {smallScreen && (
-          <Flex align="flex-start" direction="column" m={2}>
-            <Text color="greyText" fontSize="sm">
-              From
-            </Text>
-            <Text fontWeight="bold" fontSize="lg">
-              {getNetworkName(chainId)}
-            </Text>
+        {!smallScreen && (
+          <Flex w="100%" justify="space-between">
+            <Flex align="flex-start" direction="column">
+              <Text color="greyText" fontSize="sm">
+                From
+              </Text>
+              <Text fontWeight="bold" fontSize="lg">
+                {getNetworkName(chainId)}
+              </Text>
+            </Flex>
+            {isERC20Dai && <DaiWarning />}
+            {showReverseBridgeWarning && <ReverseWarning />}
+            <Flex align="flex-end" direction="column">
+              <Text color="greyText" fontSize="sm">
+                To
+              </Text>
+              <Text fontWeight="bold" fontSize="lg" textAlign="right">
+                {getNetworkName(bridgeChainId)}
+              </Text>
+            </Flex>
           </Flex>
         )}
-        <FromToken />
-        <Flex
-          direction="column"
-          px={{ base: 2, lg: 4 }}
-          my={{ base: 2, lg: 0 }}
-          align="center"
-          w="100%"
+        <Grid
+          templateColumns={{ base: 'initial', lg: '2fr 1fr 2fr' }}
+          width="100%"
+          my={4}
         >
-          <UnlockButton />
-          <TransferButton />
-        </Flex>
-        {smallScreen && (
-          <Flex align="flex-end" direction="column" m={2}>
-            <Text color="greyText" fontSize="sm">
-              To
-            </Text>
-            <Text fontWeight="bold" fontSize="lg" textAlign="right">
-              {getNetworkName(bridgeChainId)}
-            </Text>
+          {smallScreen && isERC20Dai && <DaiWarning />}
+          {smallScreen && showReverseBridgeWarning && (
+            <ReverseWarning isSmallScreen />
+          )}
+          {smallScreen && (
+            <Flex align="flex-start" direction="column" m={2}>
+              <Text color="greyText" fontSize="sm">
+                From
+              </Text>
+              <Text fontWeight="bold" fontSize="lg">
+                {getNetworkName(chainId)}
+              </Text>
+            </Flex>
+          )}
+          <FromToken />
+          <Flex
+            direction="column"
+            px={{ base: 2, lg: 4 }}
+            my={{ base: 2, lg: 0 }}
+            align="center"
+            w="100%"
+          >
+            <UnlockButton />
+            <TransferButton />
           </Flex>
-        )}
-        <ToToken />
-      </Grid>
-      <AdvancedMenu />
-      <SystemFeedback />
+          {smallScreen && (
+            <Flex align="flex-end" direction="column" m={2}>
+              <Text color="greyText" fontSize="sm">
+                To
+              </Text>
+              <Text fontWeight="bold" fontSize="lg" textAlign="right">
+                {getNetworkName(bridgeChainId)}
+              </Text>
+            </Flex>
+          )}
+          <ToToken />
+        </Grid>
+        <AdvancedMenu />
+        <SystemFeedback />
+      </Flex>
     </Flex>
   );
 };

--- a/packages/react-app/src/components/bridge/RPCHealthAlert.jsx
+++ b/packages/react-app/src/components/bridge/RPCHealthAlert.jsx
@@ -1,0 +1,50 @@
+import { Flex, Image, Text } from '@chakra-ui/react';
+import AlertImage from 'assets/alert.svg';
+import { useBridgeDirection } from 'hooks/useBridgeDirection';
+import { useRPCHealth } from 'hooks/useRPCHealth';
+import { getNetworkName } from 'lib/helpers';
+import React from 'react';
+
+export const RPCHealthAlert = () => {
+  const { foreignHealthy, homeHealthy } = useRPCHealth();
+  const { foreignChainId, homeChainId } = useBridgeDirection();
+
+  if (foreignHealthy && homeHealthy) return null;
+
+  const bothSides = !homeHealthy && !foreignHealthy;
+
+  return (
+    <Flex w="100%" align="center" mb={4}>
+      <Flex
+        w="100%"
+        borderRadius="0.5rem"
+        border="1px solid #DAE3F0"
+        bg="white"
+      >
+        <Flex
+          bg="#FFF7EF"
+          borderLeftRadius="0.5rem"
+          border="1px solid #FFAA5C"
+          justify="center"
+          align="center"
+          minW="4rem"
+          maxW="4rem"
+          flex={1}
+        >
+          <Image src={AlertImage} />
+        </Flex>
+        <Flex align="center" p={4}>
+          <Text fontSize="0.75rem">
+            {`The ${!homeHealthy ? getNetworkName(homeChainId) : ''} ${
+              bothSides ? 'and' : ''
+            } ${
+              !foreignHealthy ? getNetworkName(foreignChainId) : ''
+            } RPC-node${
+              bothSides ? 's are' : ' is'
+            } not responding. Please set custom RPC URL in settings or come back later.`}
+          </Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/react-app/src/components/history/BridgeHistory.jsx
+++ b/packages/react-app/src/components/history/BridgeHistory.jsx
@@ -1,11 +1,10 @@
-import { Checkbox, Flex, Grid, Image, Text } from '@chakra-ui/react';
-import AlertImage from 'assets/alert.svg';
+import { Checkbox, Flex, Grid, Text } from '@chakra-ui/react';
+import { GraphHealthAlert } from 'components/history/GraphHealthAlert';
 import { HistoryItem } from 'components/history/HistoryItem';
 import { HistoryPagination } from 'components/history/HistoryPagination';
 import { ManualClaim } from 'components/history/ManualClaim';
 import { NoHistory } from 'components/history/NoHistory';
 import { LoadingModal } from 'components/modals/LoadingModal';
-import { useGraphHealth } from 'hooks/useGraphHealth';
 import { useUserHistory } from 'hooks/useUserHistory';
 import React, { useState } from 'react';
 import { Redirect } from 'react-router-dom';
@@ -16,12 +15,6 @@ export const BridgeHistory = ({ page }) => {
   const [onlyUnReceived, setOnlyUnReceived] = useState(false);
 
   const { transfers, loading } = useUserHistory();
-  const { foreignHealthy, homeHealthy } = useGraphHealth(
-    'Cannot access history data. Wait for a few minutes and reload the application',
-    {
-      disableAlerts: true,
-    },
-  );
 
   if (loading) {
     return (
@@ -52,6 +45,8 @@ export const BridgeHistory = ({ page }) => {
       px={{ base: 4, sm: 8 }}
       w="100%"
     >
+      <GraphHealthAlert />
+      <ManualClaim />
       <Flex justify="space-between" align="center" mb={4}>
         <Text fontSize="xl" fontWeight="bold">
           History
@@ -67,38 +62,6 @@ export const BridgeHistory = ({ page }) => {
           <Text fontSize="sm">Show only unreceived</Text>
         </Checkbox>
       </Flex>
-
-      {!(foreignHealthy && homeHealthy) && (
-        <Flex w="100%" align="center" mb={4}>
-          <Flex
-            w="100%"
-            borderRadius="0.5rem"
-            border="1px solid #DAE3F0"
-            bg="white"
-          >
-            <Flex
-              bg="#FFF7EF"
-              borderLeftRadius="0.5rem"
-              border="1px solid #FFAA5C"
-              justify="center"
-              align="center"
-              minW="4rem"
-              maxW="4rem"
-              flex={1}
-            >
-              <Image src={AlertImage} />
-            </Flex>
-            <Flex align="center" p={4}>
-              <Text fontSize="0.75rem">
-                The Graph service may not work properly and some transfers may
-                not display. You can use the form below to claim your tokens.
-              </Text>
-            </Flex>
-          </Flex>
-        </Flex>
-      )}
-
-      <ManualClaim />
 
       {displayHistory.length > 0 ? (
         <>

--- a/packages/react-app/src/components/history/BridgeHistory.jsx
+++ b/packages/react-app/src/components/history/BridgeHistory.jsx
@@ -1,6 +1,8 @@
-import { Checkbox, Flex, Grid, Text } from '@chakra-ui/react';
+import { Checkbox, Flex, Grid, Image, Text } from '@chakra-ui/react';
+import AlertImage from 'assets/alert.svg';
 import { HistoryItem } from 'components/history/HistoryItem';
 import { HistoryPagination } from 'components/history/HistoryPagination';
+import { ManualClaim } from 'components/history/ManualClaim';
 import { NoHistory } from 'components/history/NoHistory';
 import { LoadingModal } from 'components/modals/LoadingModal';
 import { useGraphHealth } from 'hooks/useGraphHealth';
@@ -14,8 +16,11 @@ export const BridgeHistory = ({ page }) => {
   const [onlyUnReceived, setOnlyUnReceived] = useState(false);
 
   const { transfers, loading } = useUserHistory();
-  useGraphHealth(
+  const { foreignHealthy, homeHealthy } = useGraphHealth(
     'Cannot access history data. Wait for a few minutes and reload the application',
+    {
+      disableAlerts: true,
+    },
   );
 
   if (loading) {
@@ -62,6 +67,38 @@ export const BridgeHistory = ({ page }) => {
           <Text fontSize="sm">Show only unreceived</Text>
         </Checkbox>
       </Flex>
+
+      {!(foreignHealthy && homeHealthy) && (
+        <Flex w="100%" align="center" mb={4}>
+          <Flex
+            w="100%"
+            borderRadius="0.5rem"
+            border="1px solid #DAE3F0"
+            bg="white"
+          >
+            <Flex
+              bg="#FFF7EF"
+              borderLeftRadius="0.5rem"
+              border="1px solid #FFAA5C"
+              justify="center"
+              align="center"
+              minW="4rem"
+              maxW="4rem"
+              flex={1}
+            >
+              <Image src={AlertImage} />
+            </Flex>
+            <Flex align="center" p={4}>
+              <Text fontSize="0.75rem">
+                The Graph service may not work properly and some transfers may
+                not display. You can use the form below to claim your tokens.
+              </Text>
+            </Flex>
+          </Flex>
+        </Flex>
+      )}
+
+      <ManualClaim />
 
       {displayHistory.length > 0 ? (
         <>

--- a/packages/react-app/src/components/history/GraphHealthAlert.jsx
+++ b/packages/react-app/src/components/history/GraphHealthAlert.jsx
@@ -1,0 +1,44 @@
+import { Flex, Image, Text } from '@chakra-ui/react';
+import AlertImage from 'assets/alert.svg';
+import { useGraphHealth } from 'hooks/useGraphHealth';
+import React from 'react';
+
+export const GraphHealthAlert = () => {
+  const { foreignHealthy, homeHealthy } = useGraphHealth(
+    'Cannot access history data. Wait for a few minutes and reload the application',
+    {
+      disableAlerts: true,
+    },
+  );
+  if (foreignHealthy && homeHealthy) return null;
+
+  return (
+    <Flex w="100%" align="center" mb={4}>
+      <Flex
+        w="100%"
+        borderRadius="0.5rem"
+        border="1px solid #DAE3F0"
+        bg="white"
+      >
+        <Flex
+          bg="#FFF7EF"
+          borderLeftRadius="0.5rem"
+          border="1px solid #FFAA5C"
+          justify="center"
+          align="center"
+          minW="4rem"
+          maxW="4rem"
+          flex={1}
+        >
+          <Image src={AlertImage} />
+        </Flex>
+        <Flex align="center" p={4}>
+          <Text fontSize="0.75rem">
+            The Graph service may not work properly and some transfers may not
+            display. You can use the form below to claim your tokens.
+          </Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/react-app/src/components/history/ManualClaim.jsx
+++ b/packages/react-app/src/components/history/ManualClaim.jsx
@@ -1,0 +1,98 @@
+import {
+  Button,
+  Flex,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Text,
+  useToast,
+} from '@chakra-ui/react';
+import { useManualClaim } from 'hooks/useManualClaim';
+import { logError } from 'lib/helpers';
+import React, { useCallback, useState } from 'react';
+
+export const ManualClaim = () => {
+  const [txHash, setTxHash] = useState('');
+  const [loading, setLoading] = useState(false);
+  const isInvalid = !txHash;
+  const claim = useManualClaim();
+
+  const toast = useToast();
+  const showError = useCallback(
+    msg => {
+      if (msg) {
+        toast({
+          title: 'Error',
+          description: msg,
+          status: 'error',
+          isClosable: 'true',
+        });
+      }
+    },
+    [toast],
+  );
+
+  const claimTokens = useCallback(async () => {
+    if (isInvalid) return;
+    setLoading(true);
+    try {
+      await claim(txHash);
+    } catch (manualClaimError) {
+      logError({ manualClaimError });
+      showError(manualClaimError.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [claim, txHash, isInvalid, showError]);
+
+  return (
+    <Flex
+      w="100%"
+      justify="space-between"
+      mb="4"
+      align="center"
+      bg="white"
+      p="1rem"
+      borderRadius="0.5rem"
+      direction={{ base: 'column', lg: 'row' }}
+    >
+      <Flex
+        direction="column"
+        fontSize="sm"
+        w="100%"
+        minW={{ base: 'auto', lg: '25rem' }}
+        mb={{ base: '2', lg: '0' }}
+      >
+        <Text color="black">
+          Can&apos;t find your transfer to claim tokens?
+        </Text>
+        <Text color="greyText">
+          Enter the transaction hash where the token transfer happened{' '}
+        </Text>
+      </Flex>
+      <InputGroup>
+        <Input
+          borderColor="#DAE3F0"
+          bg="white"
+          fontSize="sm"
+          placeholder="Transaction Hash"
+          value={txHash}
+          onChange={e => setTxHash(e.target.value)}
+          pr="6rem"
+        />
+        <InputRightElement minW="6rem" pr="1">
+          <Button
+            w="100%"
+            size="sm"
+            colorScheme="blue"
+            onClick={claimTokens}
+            isDisabled={isInvalid}
+            isLoading={loading}
+          >
+            Claim
+          </Button>
+        </InputRightElement>
+      </InputGroup>
+    </Flex>
+  );
+};

--- a/packages/react-app/src/components/history/ManualClaim.jsx
+++ b/packages/react-app/src/components/history/ManualClaim.jsx
@@ -54,6 +54,7 @@ export const ManualClaim = () => {
       bg="white"
       p="1rem"
       borderRadius="0.5rem"
+      boxShadow="0px 1rem 2rem rgba(204, 218, 238, 0.8)"
       direction={{ base: 'column', lg: 'row' }}
     >
       <Flex

--- a/packages/react-app/src/components/modals/AddToMetamaskModal.jsx
+++ b/packages/react-app/src/components/modals/AddToMetamaskModal.jsx
@@ -131,12 +131,12 @@ export const AddToMetamaskModal = ({ isOpen, onClose, token: tokenToAdd }) => {
                 <Flex
                   mt={4}
                   w="100%"
-                  borderRadius="4px"
+                  borderRadius="0.25rem"
                   border="1px solid #DAE3F0"
                 >
                   <Flex
                     bg="rgba(255, 102, 92, 0.1)"
-                    borderLeftRadius="4px"
+                    borderLeftRadius="0.25rem"
                     border="1px solid #FF665C"
                     justify="center"
                     align="center"
@@ -146,7 +146,7 @@ export const AddToMetamaskModal = ({ isOpen, onClose, token: tokenToAdd }) => {
                   >
                     <Image src={ErrorImage} />
                   </Flex>
-                  <Flex align="center" fontSize="12px" p={4}>
+                  <Flex align="center" fontSize="0.75rem" p={4}>
                     <Text>
                       <Text as="span">{`Please switch the network in your wallet to `}</Text>
                       <Text as="b">{`${getNetworkName(token.chainId)}`}</Text>

--- a/packages/react-app/src/components/modals/BridgeLoadingModal.jsx
+++ b/packages/react-app/src/components/modals/BridgeLoadingModal.jsx
@@ -31,6 +31,7 @@ export const BridgeLoadingModal = () => {
   );
   useGraphHealth(
     'Cannot collect data to finalize the transfer. Wait for a few minutes, reload the application and look for your unclaimed transactions in the History tab',
+    { disableAlerts: !txHash },
   );
   const {
     loadingText,

--- a/packages/react-app/src/components/modals/ClaimTransferModal.jsx
+++ b/packages/react-app/src/components/modals/ClaimTransferModal.jsx
@@ -215,13 +215,13 @@ export const ClaimTransferModal = () => {
               <Flex
                 mt={4}
                 w="100%"
-                borderRadius="4px"
+                borderRadius="0.25rem"
                 border="1px solid #DAE3F0"
                 mb={executed ? 6 : 0}
               >
                 <Flex
                   bg="rgba(83, 164, 255, 0.1)"
-                  borderLeftRadius="4px"
+                  borderLeftRadius="0.25rem"
                   border="1px solid #53A4FF"
                   justify="center"
                   align="center"
@@ -231,7 +231,7 @@ export const ClaimTransferModal = () => {
                 >
                   <Image src={InfoImage} />
                 </Flex>
-                <Flex align="center" fontSize="12px" p={4}>
+                <Flex align="center" fontSize="0.75rem" p={4}>
                   <Text>
                     {`The claim process may take a variable period of time on ${getNetworkName(
                       foreignChainId,
@@ -242,10 +242,14 @@ export const ClaimTransferModal = () => {
                 </Flex>
               </Flex>
               {executed && (
-                <Flex w="100%" borderRadius="4px" border="1px solid #DAE3F0">
+                <Flex
+                  w="100%"
+                  borderRadius="0.25rem"
+                  border="1px solid #DAE3F0"
+                >
                   <Flex
                     bg="rgba(255, 102, 92, 0.1)"
-                    borderLeftRadius="4px"
+                    borderLeftRadius="0.25rem"
                     border="1px solid #FF665C"
                     justify="center"
                     align="center"
@@ -255,7 +259,7 @@ export const ClaimTransferModal = () => {
                   >
                     <Image src={ErrorImage} />
                   </Flex>
-                  <Flex align="center" fontSize="12px" p={4}>
+                  <Flex align="center" fontSize="0.75rem" p={4}>
                     <Text>The transfer request was already executed</Text>
                   </Flex>
                 </Flex>

--- a/packages/react-app/src/components/modals/NeedsConfirmationModal.jsx
+++ b/packages/react-app/src/components/modals/NeedsConfirmationModal.jsx
@@ -60,13 +60,13 @@ export const NeedsConfirmationModal = ({ setNeedsConfirmation }) => {
               <Flex
                 mt={4}
                 w="100%"
-                borderRadius="4px"
+                borderRadius="0.25rem"
                 border="1px solid #DAE3F0"
                 mb={6}
               >
                 <Flex
                   bg="rgba(83, 164, 255, 0.1)"
-                  borderLeftRadius="4px"
+                  borderLeftRadius="0.25rem"
                   border="1px solid #53A4FF"
                   justify="center"
                   align="center"
@@ -76,7 +76,7 @@ export const NeedsConfirmationModal = ({ setNeedsConfirmation }) => {
                 >
                   <Image src={InfoImage} />
                 </Flex>
-                <Flex align="center" fontSize="12px" p={4}>
+                <Flex align="center" fontSize="0.75rem" p={4}>
                   <Text>
                     After you switch networks, you will complete a second
                     transaction on {getNetworkName(foreignChainId)} to claim

--- a/packages/react-app/src/components/modals/NeedsTransactionsModal.jsx
+++ b/packages/react-app/src/components/modals/NeedsTransactionsModal.jsx
@@ -42,10 +42,10 @@ export const NeedsTransactions = () => {
   }
 
   return (
-    <Flex mt={4} w="100%" borderRadius="4px" border="1px solid #DAE3F0">
+    <Flex mt={4} w="100%" borderRadius="0.25rem" border="1px solid #DAE3F0">
       <Flex
         bg="#FFF7EF"
-        borderLeftRadius="4px"
+        borderLeftRadius="0.25rem"
         border="1px solid #FFAA5C"
         justify="center"
         align="center"
@@ -54,7 +54,7 @@ export const NeedsTransactions = () => {
       >
         <Image src={AlertImage} />
       </Flex>
-      <Flex align="center" fontSize="12px" p={2} pl={4}>
+      <Flex align="center" fontSize="0.75rem" p={2} pl={4}>
         <Text>
           {`The claim process requires 2 transactions, one on ${getNetworkName(
             homeChainId,

--- a/packages/react-app/src/contexts/BridgeContext.jsx
+++ b/packages/react-app/src/contexts/BridgeContext.jsx
@@ -23,9 +23,11 @@ import {
   parseValue,
 } from 'lib/helpers';
 import { fetchTokenDetails } from 'lib/token';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 export const BridgeContext = React.createContext({});
+
+export const useBridgeContext = () => useContext(BridgeContext);
 
 export const BridgeProvider = ({ children }) => {
   const { queryToken, setQueryToken } = useSettings();

--- a/packages/react-app/src/hooks/useGraphHealth.js
+++ b/packages/react-app/src/hooks/useGraphHealth.js
@@ -51,17 +51,17 @@ export const useGraphHealth = (
     const load = async () => {
       try {
         setLoading(true);
-        const hChainId = await getEthersProvider(homeChainId);
-        const fChainId = await getEthersProvider(foreignChainId);
-        if (!hChainId || !fChainId) return;
+        const homeProvider = await getEthersProvider(homeChainId);
+        const foreignProvider = await getEthersProvider(foreignChainId);
+        if (!homeProvider || !foreignProvider) return;
         const [
           { homeHealth, foreignHealth },
           homeBlockNumber,
           foreignBlockNumber,
         ] = await Promise.all([
           getHealthStatus(bridgeDirection),
-          hChainId?.getBlockNumber(),
-          fChainId?.getBlockNumber(),
+          homeProvider?.getBlockNumber(),
+          foreignProvider?.getBlockNumber(),
         ]);
         logDebug({
           homeHealth,

--- a/packages/react-app/src/hooks/useGraphHealth.js
+++ b/packages/react-app/src/hooks/useGraphHealth.js
@@ -24,7 +24,11 @@ const THRESHOLD_BLOCKS =
   REACT_APP_GRAPH_HEALTH_THRESHOLD_BLOCKS ||
   DEFAULT_GRAPH_HEALTH_THRESHOLD_BLOCKS;
 
-export const useGraphHealth = (description, onlyHome = false) => {
+export const useGraphHealth = (
+  description,
+  options = { onlyHome: false, disableAlerts: false },
+) => {
+  const { onlyHome, disableAlerts } = options;
   const { bridgeDirection, homeChainId, foreignChainId } = useBridgeDirection();
   const { providerChainId } = useWeb3Context();
 
@@ -118,7 +122,7 @@ export const useGraphHealth = (description, onlyHome = false) => {
         toast.close(toastIdRef.current);
       }
       if (!(homeHealthy && foreignHealthy)) {
-        if (onlyHome && !isHome) return;
+        if ((onlyHome === true && !isHome) || disableAlerts === true) return;
         toastIdRef.current = toast({
           title: 'Subgraph Error',
           description,
@@ -135,6 +139,9 @@ export const useGraphHealth = (description, onlyHome = false) => {
     toast,
     onlyHome,
     isHome,
+    disableAlerts,
     description,
   ]);
+
+  return { homeHealthy, foreignHealthy };
 };

--- a/packages/react-app/src/hooks/useLocalState.js
+++ b/packages/react-app/src/hooks/useLocalState.js
@@ -19,7 +19,7 @@ export const useLocalState = (
     return storageValue;
   }, [storageValue, valueType]);
 
-  const [value, setValue] = useState(initialValue || castedValue);
+  const [value, setValue] = useState(castedValue || initialValue);
 
   const updateValue = useCallback(
     (val, shouldBeStored = false) => {

--- a/packages/react-app/src/hooks/useManualClaim.js
+++ b/packages/react-app/src/hooks/useManualClaim.js
@@ -1,0 +1,111 @@
+import { useWeb3Context } from 'contexts/Web3Context';
+import { Contract, utils } from 'ethers';
+import { useBridgeDirection } from 'hooks/useBridgeDirection';
+import { executeSignatures } from 'lib/amb';
+import { getNetworkName } from 'lib/helpers';
+import { getEthersProvider } from 'lib/providers';
+import { useCallback } from 'react';
+
+const getMessageData = async (ethersProvider, txHash) => {
+  const abi = new utils.Interface([
+    'event UserRequestForSignature(bytes32 indexed messageId, bytes encodedData)',
+  ]);
+  let receipt;
+  try {
+    receipt = await ethersProvider.getTransactionReceipt(txHash);
+  } catch (error) {
+    throw Error('Invalid hash.');
+  }
+  if (!receipt || !receipt.logs) {
+    throw Error('No transaction found.');
+  }
+  const eventFragment = abi.events[Object.keys(abi.events)[0]];
+  const eventTopic = abi.getEventTopic(eventFragment);
+  const event = receipt.logs.find(e => e.topics[0] === eventTopic);
+  if (!event) {
+    throw Error(
+      'It is not a bridge transaction. Specify hash of a transaction sending tokens to the bridge.',
+    );
+  }
+  const decodedLog = abi.decodeEventLog(
+    eventFragment,
+    event.data,
+    event.topics,
+  );
+  return decodedLog.encodedData;
+};
+
+const getMessage = async (homeProvider, homeAmbAddress, txHash) => {
+  const msgData = await getMessageData(homeProvider, txHash);
+  const messageHash = utils.solidityKeccak256(['bytes'], [msgData]);
+
+  const abi = [
+    'event CollectedSignatures(address authorityResponsibleForRelay, bytes32 messageHash, uint256 NumberOfCollectedSignatures)',
+    'function signature(bytes32 _hash, uint256 _index) public view returns (bytes)',
+  ];
+  const homeAMB = new Contract(homeAmbAddress, abi, homeProvider);
+  let events = await homeAMB.queryFilter('CollectedSignatures', 12123723);
+  events = events.filter(x => x.args.messageHash === messageHash);
+  if (events.length === 0) {
+    throw Error(
+      'Transaction to the bridge is found but oracles’ confirmations are not collected yet. Wait for a minute and try again.',
+    );
+  }
+  const event = events[0];
+  const n = parseInt(event.args.NumberOfCollectedSignatures, 10);
+  const signatures = await Promise.all(
+    Array(n)
+      .fill(null)
+      .map((_item, index) => homeAMB.signature(messageHash, index)),
+  );
+  return {
+    msgData,
+    signatures,
+  };
+};
+
+export function useManualClaim() {
+  const {
+    homeChainId,
+    homeAmbAddress,
+    foreignChainId,
+    foreignAmbAddress,
+  } = useBridgeDirection();
+  const { providerChainId, ethersProvider } = useWeb3Context();
+
+  return useCallback(
+    async txHash => {
+      if (providerChainId !== foreignChainId) {
+        throw Error(
+          `Wrong network. Please connect your wallet to ${getNetworkName(
+            foreignChainId,
+          )}.`,
+        );
+      }
+      const homeProvider = await getEthersProvider(homeChainId);
+      const message = await getMessage(homeProvider, homeAmbAddress, txHash);
+      const abi = [
+        'function relayedMessages(bytes32 _txHash) public view returns (bool)',
+      ];
+      const foreignAMB = new Contract(foreignAmbAddress, abi, ethersProvider);
+      const claimed = await foreignAMB.relayedMessages(txHash);
+      if (claimed) {
+        throw Error(
+          `Tokens are already claimed. Check your token balance on ${getNetworkName(
+            foreignChainId,
+          )}.`,
+        );
+      }
+      await executeSignatures(ethersProvider, foreignAmbAddress, message);
+      return true;
+    },
+    [
+      homeChainId,
+      homeAmbAddress,
+      foreignChainId,
+      foreignAmbAddress,
+      providerChainId,
+      ethersProvider,
+    ],
+  );
+}

--- a/packages/react-app/src/hooks/useRPCHealth.js
+++ b/packages/react-app/src/hooks/useRPCHealth.js
@@ -1,0 +1,65 @@
+import { useBridgeDirection } from 'hooks/useBridgeDirection';
+import { logDebug, logError } from 'lib/helpers';
+import { getEthersProvider } from 'lib/providers';
+import { useEffect, useState } from 'react';
+import { defer } from 'rxjs';
+
+const { REACT_APP_RPC_HEALTH_UPDATE_INTERVAL } = process.env;
+
+const DEFAULT_RPC_HEALTH_UPDATE_INTERVAL = 15000;
+
+const UPDATE_INTERVAL =
+  REACT_APP_RPC_HEALTH_UPDATE_INTERVAL || DEFAULT_RPC_HEALTH_UPDATE_INTERVAL;
+
+export const useRPCHealth = () => {
+  const { homeChainId, foreignChainId } = useBridgeDirection();
+
+  const [{ homeHealthy, foreignHealthy }, setHealthStatus] = useState({
+    homeHealthy: true,
+    foreignHealthy: true,
+  });
+
+  useEffect(() => {
+    const subscriptions = [];
+    const unsubscribe = () => {
+      subscriptions.forEach(s => {
+        clearTimeout(s);
+      });
+    };
+
+    const load = async () => {
+      try {
+        const homeProvider = await getEthersProvider(homeChainId);
+        const homeHealth = homeProvider !== null;
+        const foreignProvider = await getEthersProvider(foreignChainId);
+        const foreignHealth = foreignProvider !== null;
+        setHealthStatus({
+          homeHealthy: homeHealth,
+          foreignHealthy: foreignHealth,
+        });
+        logDebug({
+          homeHealth,
+          foreignHealth,
+          message: 'updated rpc health data',
+        });
+
+        const timeoutId = setTimeout(() => load(), UPDATE_INTERVAL);
+        subscriptions.push(timeoutId);
+      } catch (graphHealthError) {
+        logError({ graphHealthError });
+      }
+    };
+
+    // unsubscribe from previous polls
+    unsubscribe();
+
+    const deferral = defer(() => load()).subscribe();
+    // unsubscribe when unmount component
+    return () => {
+      unsubscribe();
+      deferral.unsubscribe();
+    };
+  }, [foreignChainId, homeChainId]);
+
+  return { homeHealthy, foreignHealthy };
+};

--- a/packages/react-app/src/lib/amb.js
+++ b/packages/react-app/src/lib/amb.js
@@ -37,15 +37,17 @@ function packSignatures(array) {
   return `0x${msgLength}${v}${r}${s}`;
 }
 
-export const executeSignatures = async (ethersProvider, address, message) => {
+export const executeSignatures = async (
+  ethersProvider,
+  address,
+  { msgData, signatures },
+) => {
   const abi = [
     'function executeSignatures(bytes messageData, bytes signatures) external',
   ];
-  const signatures = packSignatures(
-    message.signatures.map(s => signatureToVRS(s)),
-  );
+  const signs = packSignatures(signatures.map(s => signatureToVRS(s)));
   const ambContract = new Contract(address, abi, ethersProvider.getSigner());
-  return ambContract.executeSignatures(message.msgData, signatures);
+  return ambContract.executeSignatures(msgData, signs);
 };
 
 const messagesTXQuery = gql`

--- a/packages/react-app/src/lib/providers.js
+++ b/packages/react-app/src/lib/providers.js
@@ -25,7 +25,9 @@ const memoized = memoize(
 
 export const getEthersProvider = async chainId => {
   const localRPCUrl = window.localStorage.getItem(RPC_URL[chainId]);
-  const rpcURLs = localRPCUrl ? [localRPCUrl] : getRPCUrl(chainId, true);
+  const rpcURLs = localRPCUrl
+    ? [localRPCUrl].concat(getRPCUrl(chainId, true))
+    : getRPCUrl(chainId, true);
   const provider = (
     await Promise.all(
       rpcURLs.map(async url => {

--- a/packages/react-app/src/lib/providers.js
+++ b/packages/react-app/src/lib/providers.js
@@ -24,10 +24,8 @@ const memoized = memoize(
 );
 
 export const getEthersProvider = async chainId => {
-  const localRPCUrl = window.localStorage.getItem(
-    RPC_URL[chainId] || RPC_URL[1],
-  );
-  const rpcURLs = localRPCUrl || getRPCUrl(chainId, true);
+  const localRPCUrl = window.localStorage.getItem(RPC_URL[chainId]);
+  const rpcURLs = localRPCUrl ? [localRPCUrl] : getRPCUrl(chainId, true);
   const provider = (
     await Promise.all(
       rpcURLs.map(async url => {


### PR DESCRIPTION
Removed unnessary multiple alerts on the bridge interface.
Now the graph health alert will show up only when a transfer/claim is in progress on the bridge page.

On the history page, it won't show a toast instead shows an alert at the top as shown below. And also allows the user to manually claim a tx (similar to the xDai bridge).
![Screenshot from 2021-04-16 18:51:31](https://user-images.githubusercontent.com/10012209/115033202-c5513680-9ee7-11eb-8909-5d1f5c619c78.png)

On the bridge page, in case there are issues with the RPC, then an alert is shown as below (similar to the xDai bridge).
![Screenshot from 2021-04-16 18:51:01](https://user-images.githubusercontent.com/10012209/115033293-e44fc880-9ee7-11eb-8215-0731e62f6088.png)


This PR closes #212 